### PR TITLE
feat: first-class Google Antigravity engine (engine: 'agy')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has no structured output mode as of 1.0.16), so token counts are estimated.
   New registry models: `gemini-3.5-flash` (alias `agy-flash`) and `gemini-3.1-pro`
   (alias `agy-pro`); agy-proxied Claude/GPT-OSS models pass through unregistered.
+  Behavior change: bare `gemini-3.5-flash` / `gemini-3.1-pro` now route to
+  `engine: 'agy'` and require the `agy` binary; use the preview Gemini CLI slugs
+  (`gemini-3-flash-preview`, `gemini-3.1-pro-preview`) for the `gemini` engine.
   Unknown model slugs silently fall back to agy's default (verified on 1.0.16).
   `AGY_BIN` env var overrides the binary. Verified against `agy` 1.0.16, including
   a live two-turn resume test.
+
+### Changed
+- **stderr secret redaction unified across engines** (`src/sanitize.ts`). The claude,
+  gemini, cursor, opencode, custom, and agy engines now share one sanitizer whose
+  patterns are the union of the previous per-engine copies (Bearer tokens incl.
+  dotted `ya29.*`, `sk-*` keys, `api_key` assignments, and any `*_KEY=` / `*_TOKEN=` /
+  `*_SECRET=` env var) — strictly broader redaction for every engine.
 
 ## [4.6.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **First-class Google Antigravity engine (`engine: 'agy'`).** Wraps the `agy` CLI —
+  Google's successor to Gemini CLI (consumer Gemini CLI tiers stopped serving
+  2026-06-18) — as a built-in one-shot engine, replacing the custom-engine recipe.
+  Beyond the recipe it adds: **conversation continuity** (agy logs
+  `Created conversation <uuid>`; the engine passes a private `--log-file`, harvests
+  the ID after the first turn, and resumes with `--conversation <id>` — seedable via
+  `resumeSessionId`, exposed as `stats.agyConversationId`), **timeout coherence**
+  (`--print-timeout` derived from the send timeout), permission-mode mapping
+  (`bypassPermissions` → `--dangerously-skip-permissions`, `default` → `--sandbox`),
+  stderr secret redaction, and per-session log cleanup. Output is plain text (agy
+  has no structured output mode as of 1.0.16), so token counts are estimated.
+  New registry models: `gemini-3.5-flash` (alias `agy-flash`) and `gemini-3.1-pro`
+  (alias `agy-pro`); agy-proxied Claude/GPT-OSS models pass through unregistered.
+  Unknown model slugs silently fall back to agy's default (verified on 1.0.16).
+  `AGY_BIN` env var overrides the binary. Verified against `agy` 1.0.16, including
+  a live two-turn resume test.
+
 ## [4.6.0] - 2026-07-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ support. Key source files:
 | `src/persistent-session.ts` | Claude Code CLI wrapper (spawn, JSON protocol, stream parsing) |
 | `src/persistent-codex-session.ts` | Codex CLI wrapper (`codex exec --full-auto`) |
 | `src/persistent-gemini-session.ts` | Gemini CLI wrapper (`gemini -p --output-format stream-json`) |
+| `src/persistent-agy-session.ts` | Google Antigravity CLI wrapper (`agy -p`, plain text, log-harvested conversation resume) |
 | `src/persistent-cursor-session.ts` | Cursor Agent CLI wrapper (`agent -p --force --output-format stream-json`) |
 | `src/persistent-opencode-session.ts` | sst/opencode CLI wrapper (`opencode run --format json`) |
 | `src/persistent-custom-session.ts` | Custom engine — any CLI via user-provided `CustomEngineConfig` |
@@ -181,6 +182,7 @@ Current tested versions (update on each release):
 | Claude | `claude` | 2.1.199 | Persistent subprocess, `--output-format stream-json` |
 | Codex | `codex` | 0.142.4 | `codex exec --sandbox workspace-write --skip-git-repo-check --json -C <dir>` (or `codex app-server --listen stdio://` for /goal) |
 | Gemini | `gemini` | 0.43.0 | `gemini -p <msg> --output-format stream-json --skip-trust --yolo/--sandbox` |
+| Antigravity | `agy` | 1.0.16 | `agy -p <msg> --log-file <tmp> [--conversation <id>] --dangerously-skip-permissions/--sandbox --print-timeout <n>s` |
 | Cursor | `agent` | 2026.03.30 | `agent -p <msg> --force --trust --output-format stream-json --workspace <dir>` |
 | OpenCode | `opencode` | 1.1.40 | `opencode run <msg> --format json [--model provider/model]` |
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://github.com/user-attachments/assets/fbd2b0ea-28d8-4387-9894-c29cf15ba030
 | Capability                  | What it does                                                                                                                                                                                                                    | Reference                                                  |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | **Persistent Sessions**     | Long-lived coding agents kept alive across requests, with full context, tool, model, and worktree control.                                                                                                                      | [`sessions.md`](./skills/references/sessions.md)           |
-| **Multi-Engine Runtime**    | One interface over Claude Code, Codex, Gemini, Cursor Agent, OpenCode, and arbitrary custom CLIs.                                                                                                                               | [`multi-engine.md`](./skills/references/multi-engine.md)   |
+| **Multi-Engine Runtime**    | One interface over Claude Code, Codex, Gemini, Antigravity (agy), Cursor Agent, OpenCode, and arbitrary custom CLIs.                                                                                                                               | [`multi-engine.md`](./skills/references/multi-engine.md)   |
 | **Multi-Agent Council**     | Parallel agents in isolated git worktrees, voting on consensus until they agree.                                                                                                                                                | [`council.md`](./skills/references/council.md)             |
 | **Fan-out**                 | Run one task across N engine/model agents in parallel and collect their answers, with an optional synthesis pass — the cross-engine best-of-N / diverse-perspective primitive (no rounds or worktrees).                          | [`tools.md`](./skills/references/tools.md)                 |
 | **ultracode**               | `session_start({ ultracode: true })` lets Claude orchestrate a dynamic JS workflow and fan out to subagents per task (Claude engine).                                                                                            | [`tools.md`](./skills/references/tools.md)                 |
@@ -94,6 +94,7 @@ Register `clawo-mcp` with any MCP-compatible host: Hermes Agent, Claude Desktop,
 | Claude Code  | `claude`   | 2.1.199        |
 | Codex        | `codex`    | 0.142.4        |
 | Gemini       | `gemini`   | 0.43.0         |
+| Antigravity  | `agy`      | 1.0.16         |
 | Cursor Agent | `agent`    | 2026.03.30     |
 | OpenCode     | `opencode` | 1.1.40         |
 | Custom CLI   | any        | —              |

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -145,7 +145,10 @@ program
   .command('session-start [name]')
   .description('Start a persistent coding session (Claude Code, Codex, Gemini, or Cursor)')
   .option('-d, --cwd <dir>', 'Working directory')
-  .option('-e, --engine <engine>', 'Engine: claude (default), codex, gemini, or cursor')
+  .option(
+    '-e, --engine <engine>',
+    'Engine: claude (default), codex, codex-app, gemini, agy, cursor, opencode, or custom',
+  )
   .option('-m, --model <model>', 'Model to use')
   .option('--permission-mode <mode>', 'Permission mode', 'acceptEdits')
   .option('--effort <level>', 'Effort level')

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: claw-orchestrator
-description: Manage persistent coding sessions across Claude Code, Codex, Gemini, Cursor, and OpenCode engines. Use when orchestrating multi-engine coding agents, starting/sending/stopping sessions, running multi-agent council collaborations, cross-session messaging, ultraplan deep planning, ultrareview parallel code review, autoloop autonomous workspace iteration, ultraapp building deployable web apps from a structured Q&A interview, switching models/tools at runtime, or exposing the orchestrator's 65 tools as an MCP server to Hermes Agent / Claude Desktop / Cursor / Cline / Continue / Zed / Windsurf / Goose. Triggers on "start a session", "send to session", "run council", "ultraplan", "ultrareview", "autoloop", "ultraapp", "Forge tab", "build a web app", "one-click app", "AppSpec", "autonomous iteration", "iterate until goal", "deep paper review", "auto research", "switch model", "multi-agent", "coding session", "session inbox", "cursor agent", "opencode", "mcp server", "clawo-mcp", "hermes mcp", "model context protocol", "ultracode", "dynamic workflow", "fanout", "fan-out", "best-of-N", "steer turn", "interrupt turn", "fork thread", "rollback turns".
+description: Manage persistent coding sessions across Claude Code, Codex, Gemini, Antigravity (agy), Cursor, and OpenCode engines. Use when orchestrating multi-engine coding agents, starting/sending/stopping sessions, running multi-agent council collaborations, cross-session messaging, ultraplan deep planning, ultrareview parallel code review, autoloop autonomous workspace iteration, ultraapp building deployable web apps from a structured Q&A interview, switching models/tools at runtime, or exposing the orchestrator's 65 tools as an MCP server to Hermes Agent / Claude Desktop / Cursor / Cline / Continue / Zed / Windsurf / Goose. Triggers on "start a session", "send to session", "run council", "ultraplan", "ultrareview", "autoloop", "ultraapp", "Forge tab", "build a web app", "one-click app", "AppSpec", "autonomous iteration", "iterate until goal", "deep paper review", "auto research", "switch model", "multi-agent", "coding session", "session inbox", "cursor agent", "opencode", "mcp server", "clawo-mcp", "hermes mcp", "model context protocol", "ultracode", "dynamic workflow", "fanout", "fan-out", "best-of-N", "steer turn", "interrupt turn", "fork thread", "rollback turns".
 metadata:
   {
     "openclaw":
       {
         "emoji": "🤖",
-        "requires": { "anyBins": ["claude", "codex", "gemini", "agent"] },
+        "requires": { "anyBins": ["claude", "codex", "gemini", "agy", "agent"] },
         "install":
           [
             {
@@ -52,6 +52,7 @@ Claw Orchestrator — persistent multi-engine coding session manager for claw-st
 | `claude` | `claude` | Persistent subprocess | Multi-turn, complex tasks |
 | `codex` | `codex exec` | Per-message spawn | One-shot execution |
 | `gemini` | `gemini -p` | Per-message spawn | One-shot execution |
+| `agy` | `agy -p` | Per-message spawn | Antigravity (Gemini CLI successor); plain-text, auto conversation resume |
 | `cursor` | `agent -p` | Per-message spawn | One-shot execution |
 | `opencode` | `opencode run` | Per-message spawn | Provider-agnostic (`provider/model`) |
 
@@ -62,6 +63,7 @@ Claw Orchestrator — persistent multi-engine coding session manager for claw-st
 session_start({ name: "myproject", cwd: "/path/to/project", engine: "claude" })
 session_start({ name: "codex-task", cwd: "/path/to/project", engine: "codex" })
 session_start({ name: "gemini-task", cwd: "/path/to/project", engine: "gemini" })
+session_start({ name: "agy-task", cwd: "/path/to/project", engine: "agy" })
 session_start({ name: "cursor-task", cwd: "/path/to/project", engine: "cursor" })
 session_start({ name: "opencode-task", cwd: "/path/to/project", engine: "opencode", model: "anthropic/claude-sonnet-4" })
 
@@ -80,7 +82,7 @@ session_stop({ name: "myproject" })
 
 | Parameter | Description |
 |-----------|-------------|
-| `engine` | `claude` (default), `codex`, `gemini`, `cursor`, `opencode` |
+| `engine` | `claude` (default), `codex`, `gemini`, `agy`, `cursor`, `opencode` |
 | `model` | Model name or alias (`fable`, `opus`, `sonnet`, `haiku`, `gpt-5.5`, `gemini-pro`, `composer-2`) |
 | `permissionMode` | `acceptEdits`, `auto`, `plan`, `bypassPermissions`, `default` |
 | `effort` | `low`, `medium`, `high`, `xhigh`, `max`, `auto` (`xhigh` is Opus 4.7-only, between `high` and `max`) |

--- a/skills/references/cli.md
+++ b/skills/references/cli.md
@@ -43,7 +43,8 @@ The server exposes an OpenAI-compatible chat completions endpoint, enabling any 
 - `claude-*`, `opus`, `sonnet`, `haiku` → Claude engine
 - `gpt-*` → Codex engine
 - `composer-*` → Cursor engine
-- `gemini-*` → Gemini engine
+- `gemini-3.5-flash`, `gemini-3.1-pro`, `agy-*`, `agy/*` → Antigravity (`agy`) engine
+- other `gemini-*` → Gemini engine
 
 **CORS:** `/v1/` paths allow cross-origin requests by default. Set `OPENCLAW_CORS_ORIGINS=*` to allow all origins on all paths.
 
@@ -60,7 +61,7 @@ clawo session-start [name] [options]
 | Flag | Description |
 |------|-------------|
 | `-d, --cwd <dir>` | Working directory |
-| `-e, --engine <engine>` | Engine: `claude` (default), `codex`, or `gemini` |
+| `-e, --engine <engine>` | Engine: `claude` (default), `codex`, `codex-app`, `gemini`, `agy`, `cursor`, `opencode`, or `custom` |
 | `-m, --model <model>` | Model name or alias |
 | `--permission-mode <mode>` | `acceptEdits`, `plan`, `auto`, `bypassPermissions` |
 | `--effort <level>` | `low`, `medium`, `high`, `max`, `auto` |

--- a/skills/references/mcp.md
+++ b/skills/references/mcp.md
@@ -223,7 +223,7 @@ Hosts deliberately do not forward your full shell environment to MCP subprocesse
 | `CLAWO_MCP_TOOLS` | Comma-separated allowlist of tool names; unlisted tools are not advertised |
 | `CLAWO_NO_EMBEDDED_SERVER` | Suppresses port 18796 binding. `clawo-mcp` sets this automatically |
 
-The engines themselves (`claude`, `codex`, `gemini`, `agent`, `opencode`) must also be installed and authenticated on the host machine — `clawo-mcp` spawns them as subprocesses, it does not bundle them.
+The engines themselves (`claude`, `codex`, `gemini`, `agy`, `agent`, `opencode`) must also be installed and authenticated on the host machine — `clawo-mcp` spawns them as subprocesses, it does not bundle them.
 
 ---
 

--- a/skills/references/multi-engine.md
+++ b/skills/references/multi-engine.md
@@ -14,6 +14,8 @@ SessionManager
 │   └── Wraps: codex app-server --listen stdio:// (long-running JSON-RPC; required for /goal)
 ├── engine: 'gemini'    → PersistentGeminiSession
 │   └── Wraps: gemini -p --output-format stream-json (per-message spawning)
+├── engine: 'agy'       → PersistentAgySession
+│   └── Wraps: agy -p (Google Antigravity CLI, per-message spawning, plain-text output)
 ├── engine: 'cursor'    → PersistentCursorSession
 │   └── Wraps: agent -p --force --trust --output-format stream-json (per-message spawning)
 ├── engine: 'opencode'  → PersistentOpencodeSession
@@ -122,6 +124,43 @@ await manager.startSession({
   name: 'gemini-task',
   engine: 'gemini',
   model: 'gemini-3.1-pro-preview',
+  cwd: '/project',
+});
+```
+
+### Google Antigravity (`engine: 'agy'`)
+
+Wraps Google's **Antigravity CLI** (`agy`) — the successor to Gemini CLI (consumer
+Gemini CLI tiers stopped serving 2026-06-18). Each `send()` spawns a new process
+in print mode. Verified against `agy` **1.0.16**.
+
+- One-shot execution per message (no persistent subprocess)
+- **Plain-text output** — agy has no structured/stream-json mode, so stdout is
+  forwarded as streaming text and **token counts are estimated** (~4 chars/token)
+- **Real conversation continuity**: agy logs `Created conversation <uuid>` to its
+  log file; the engine passes a private `--log-file`, harvests the ID after the
+  first turn, and resumes with `--conversation <id>` on subsequent sends. Seed it
+  externally via `resumeSessionId`; read it back from `getStats().agyConversationId`
+- Permission modes: `bypassPermissions` → `--dangerously-skip-permissions`,
+  `default` → `--sandbox` (terminal-restricted). Other modes run agy's own
+  approval flow, which blocks in headless print mode — use `bypassPermissions`
+  for autonomous work
+- agy enforces its own print timeout (default 5m); the engine derives
+  `--print-timeout` from the send timeout so the wrapper timer decides
+- Unknown `--model` slugs do **not** error — agy silently falls back to its
+  default model. Registered slugs: `gemini-3.5-flash` (alias `agy-flash`),
+  `gemini-3.1-pro` (alias `agy-pro`); agy also proxies Claude and GPT-OSS
+  models (`agy models` lists them) which pass through unregistered
+- Consumer auth is a one-time `agy` Google OAuth login (subscription quotas, no
+  per-token billing — registry pricing mirrors Gemini API rates as a value proxy)
+- Requires `agy` installed: `curl -fsSL https://antigravity.google/cli/install.sh | bash`
+- Binary: `agy` (set `AGY_BIN` env var to override)
+
+```typescript
+await manager.startSession({
+  name: 'antigravity-task',
+  engine: 'agy',
+  model: 'gemini-3.5-flash',
   cwd: '/project',
 });
 ```
@@ -384,9 +423,10 @@ await manager.startSession({
 
 ### Example: Google Antigravity CLI (`agy`)
 
-Google is sunsetting Gemini CLI (consumer tiers stop serving **2026-06-18**) in
-favour of the Go-based **Antigravity CLI** (`agy`). Until `agy` ships first-class
-support here, you can drive it today via a custom engine:
+> **Note:** `agy` now has first-class support — use [`engine: 'agy'`](#google-antigravity-engine-agy)
+> instead, which adds conversation resume and timeout coherence the recipe below
+> lacks. This recipe remains as a reference for driving older agy builds or
+> forks with a diverged flag surface:
 
 ```typescript
 await manager.startSession({

--- a/skills/references/multi-engine.md
+++ b/skills/references/multi-engine.md
@@ -140,7 +140,8 @@ in print mode. Verified against `agy` **1.0.16**.
 - **Real conversation continuity**: agy logs `Created conversation <uuid>` to its
   log file; the engine passes a private `--log-file`, harvests the ID after the
   first turn, and resumes with `--conversation <id>` on subsequent sends. Seed it
-  externally via `resumeSessionId`; read it back from `getStats().agyConversationId`
+  externally via `resumeSessionId` (bare UUID only); read it back from
+  `getStats().agyConversationId`
 - Permission modes: `bypassPermissions` → `--dangerously-skip-permissions`,
   `default` → `--sandbox` (terminal-restricted). Other modes run agy's own
   approval flow, which blocks in headless print mode — use `bypassPermissions`
@@ -150,7 +151,8 @@ in print mode. Verified against `agy` **1.0.16**.
 - Unknown `--model` slugs do **not** error — agy silently falls back to its
   default model. Registered slugs: `gemini-3.5-flash` (alias `agy-flash`),
   `gemini-3.1-pro` (alias `agy-pro`); agy also proxies Claude and GPT-OSS
-  models (`agy models` lists them) which pass through unregistered
+  models (`agy models` lists them) which pass through unregistered. The
+  `agy/` prefix forces Antigravity routing for provider-like model strings
 - Consumer auth is a one-time `agy` Google OAuth login (subscription quotas, no
   per-token billing — registry pricing mirrors Gemini API rates as a value proxy)
 - Requires `agy` installed: `curl -fsSL https://antigravity.google/cli/install.sh | bash`

--- a/skills/references/sessions.md
+++ b/skills/references/sessions.md
@@ -29,7 +29,7 @@ Key options:
 
 | Option | Description |
 |--------|-------------|
-| `engine` | `'claude'` (default), `'codex'`, or `'gemini'` — see [Multi-Engine](./multi-engine.md) |
+| `engine` | `'claude'` (default), `'codex'`, `'codex-app'`, `'gemini'`, `'agy'`, `'cursor'`, `'opencode'`, or `'custom'` — see [Multi-Engine](./multi-engine.md) |
 | `model` | Model alias (`opus`, `sonnet`, `haiku`, `gemini-pro`) or full name |
 | `permissionMode` | `acceptEdits`, `bypassPermissions`, `plan`, `auto`, `default` |
 | `effort` | `low`, `medium`, `high`, `max`, `auto` |

--- a/skills/references/tools.md
+++ b/skills/references/tools.md
@@ -12,7 +12,7 @@ Start a persistent coding session with full CLI flag support.
 |-----------|------|-------------|
 | `name` | string | Session name (auto-generated if omitted) |
 | `cwd` | string | Working directory |
-| `engine` | `'claude'` \| `'codex'` \| `'gemini'` \| `'cursor'` \| `'opencode'` \| `'custom'` | Engine to use (default: `claude`). `opencode` wraps sst/opencode (pass model as `provider/model`). Use `custom` with `customEngine` for any CLI. |
+| `engine` | `'claude'` \| `'codex'` \| `'codex-app'` \| `'gemini'` \| `'agy'` \| `'cursor'` \| `'opencode'` \| `'custom'` | Engine to use (default: `claude`). `agy` wraps Google Antigravity CLI. `opencode` wraps sst/opencode (pass model as `provider/model`). Use `custom` with `customEngine` for any CLI. |
 | `model` | string | Model alias or full name |
 | `permissionMode` | string | `acceptEdits`, `bypassPermissions`, `plan`, `auto`, `default` |
 | `effort` | string | `low`, `medium`, `high`, `max`, `auto` |

--- a/src/__tests__/agy-session.test.ts
+++ b/src/__tests__/agy-session.test.ts
@@ -10,8 +10,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
 
 // Mock child_process before importing the session
 const mockSpawn = vi.fn();
@@ -54,9 +52,12 @@ function closeProc(proc: ReturnType<typeof createMockProcess>, code: number) {
   proc.emit('close', code);
 }
 
-/** The deterministic per-session log path the engine passes via --log-file. */
-function logPathFor(session: InstanceType<typeof PersistentAgySession>): string {
-  return path.join(os.tmpdir(), `agy-${session.sessionId}.log`);
+/** Read the private agy log path from the actual spawn args. */
+function logPathFromSpawn(callIndex = mockSpawn.mock.calls.length - 1): string {
+  const args = mockSpawn.mock.calls[callIndex][1] as string[];
+  const idx = args.indexOf('--log-file');
+  expect(idx).toBeGreaterThan(-1);
+  return args[idx + 1];
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -166,6 +167,25 @@ describe('PersistentAgySession', () => {
       // 60s send timeout + 5s margin so the wrapper timer, not agy, decides
       expect(spawnArgs[idx + 1]).toBe('65s');
     });
+
+    it('resolves agy model aliases before passing --model', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        model: 'agy-pro',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      const idx = spawnArgs.indexOf('--model');
+      expect(idx).toBeGreaterThan(-1);
+      expect(spawnArgs[idx + 1]).toBe('gemini-3.1-pro');
+    });
   });
 
   // ─── conversation continuity ────────────────────────────────────────────
@@ -180,14 +200,11 @@ describe('PersistentAgySession', () => {
       await session.start();
 
       // Turn 1: agy writes its log; the engine harvests the new conversation ID
-      const logFile = logPathFor(session);
-      tmpLogs.push(logFile);
       const send1 = session.send('first turn', { waitForComplete: true });
+      const logFile = logPathFromSpawn();
+      tmpLogs.push(logFile);
       setTimeout(() => {
-        fs.writeFileSync(
-          logFile,
-          'I0705 server.go:825] Created conversation 4ebc13c0-4cd3-4f59-b19d-2ee98ad883b2\n',
-        );
+        fs.writeFileSync(logFile, 'I0705 server.go:825] Created conversation 4ebc13c0-4cd3-4f59-b19d-2ee98ad883b2\n');
         feedText(mockProc, 'STORED\n');
         closeProc(mockProc, 0);
       }, 10);
@@ -233,6 +250,23 @@ describe('PersistentAgySession', () => {
       expect(spawnArgs[idx + 1]).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
     });
 
+    it('ignores synthetic agy session IDs passed as resumeSessionId', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        resumeSessionId: 'agy-1720000000000-ab3f',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello again', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(spawnArgs).not.toContain('--conversation');
+    });
+
     it('keeps the existing ID when the log has no Created line (resumed turn)', async () => {
       const session = new PersistentAgySession({
         name: 'test',
@@ -242,16 +276,55 @@ describe('PersistentAgySession', () => {
       });
       await session.start();
 
-      const logFile = logPathFor(session);
-      tmpLogs.push(logFile);
       const sendPromise = session.send('hello', { waitForComplete: true });
+      const logFile = logPathFromSpawn();
+      tmpLogs.push(logFile);
       setTimeout(() => {
-        fs.writeFileSync(logFile, 'I0705 server.go:2215] GetConversationDetail: found conversation (active=true)\n');
+        fs.writeFileSync(logFile, 'I0705 server.go:825] Created conversation ffffffff-1111-2222-3333-444444444444\n');
         closeProc(mockProc, 0);
       }, 10);
       await sendPromise;
 
       expect(session.conversationId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    });
+
+    it('harvests the conversation ID even after the wrapper timeout settles the turn', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const observed = session.send('slow turn', { waitForComplete: true, timeout: 10 }).catch((err: Error) => err);
+      const logFile = logPathFromSpawn();
+      tmpLogs.push(logFile);
+      fs.writeFileSync(logFile, 'I0705 server.go:825] Created conversation 11111111-2222-3333-4444-555555555555\n');
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      closeProc(mockProc, 143);
+
+      const err = await observed;
+      expect(err.message).toContain('Timeout waiting for Antigravity response');
+      expect(session.conversationId).toBe('11111111-2222-3333-4444-555555555555');
+    });
+
+    it('logs a warning when the first turn cannot harvest a conversation ID', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const logs: string[] = [];
+      session.on('log', (msg: string) => logs.push(msg));
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      expect(logs.some((l) => l.includes('no conversation ID found in log'))).toBe(true);
     });
   });
 
@@ -333,10 +406,9 @@ describe('PersistentAgySession', () => {
       });
       await session.start();
 
-      const logFile = logPathFor(session);
-      fs.writeFileSync(logFile, 'leftover log\n');
-
       session.send('hello', { waitForComplete: false });
+      const logFile = logPathFromSpawn();
+      fs.writeFileSync(logFile, 'leftover log\n');
       session.stop();
 
       expect(mockProc.kill).toHaveBeenCalledWith('SIGTERM');
@@ -394,6 +466,30 @@ describe('PersistentAgySession', () => {
       await sendPromise;
       expect(logs.some((l) => l.includes('Bearer ***'))).toBe(true);
       expect(logs.some((l) => l.includes('ya29.secret-token'))).toBe(false);
+    });
+
+    it('redacts sk-style keys and Google API key env vars from stderr', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const logs: string[] = [];
+      session.on('log', (msg: string) => logs.push(msg));
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => {
+        mockProc.stderr.emit('data', Buffer.from('GEMINI_API_KEY=AIza12345 key=sk-proj-abcdef1234567890'));
+        closeProc(mockProc, 0);
+      }, 10);
+
+      await sendPromise;
+      expect(logs.some((l) => l.includes('GEMINI_API_KEY=***'))).toBe(true);
+      expect(logs.some((l) => l.includes('sk-***'))).toBe(true);
+      expect(logs.some((l) => l.includes('AIza12345'))).toBe(false);
+      expect(logs.some((l) => l.includes('sk-proj-abcdef'))).toBe(false);
     });
   });
 });

--- a/src/__tests__/agy-session.test.ts
+++ b/src/__tests__/agy-session.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Unit tests for PersistentAgySession
+ *
+ * Tests flag construction, plain-text collection, conversation-ID harvesting
+ * from the agy log file, timeout coherence, and stats tracking. Uses vitest
+ * mocks for child_process.spawn to avoid spawning real processes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Mock child_process before importing the session
+const mockSpawn = vi.fn();
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Import after mocking
+const { PersistentAgySession } = await import('../persistent-agy-session.js');
+
+// ─── Mock Process Helper ────────────────────────────────────────────────────
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: Readable & { destroy: ReturnType<typeof vi.fn> };
+    stderr: EventEmitter & { destroy: ReturnType<typeof vi.fn> };
+    stdin: { end: ReturnType<typeof vi.fn> };
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+    exitCode: null;
+  };
+  proc.stdout = new Readable({ read() {} });
+  (proc.stdout as Readable & { destroy: ReturnType<typeof vi.fn> }).destroy = vi.fn();
+  const stderrEmitter = new EventEmitter() as EventEmitter & { destroy: ReturnType<typeof vi.fn> };
+  stderrEmitter.destroy = vi.fn();
+  proc.stderr = stderrEmitter;
+  proc.stdin = { end: vi.fn() };
+  proc.kill = vi.fn();
+  proc.pid = 12345;
+  proc.exitCode = null;
+  return proc;
+}
+
+function feedText(proc: ReturnType<typeof createMockProcess>, text: string) {
+  proc.stdout.push(text);
+}
+
+function closeProc(proc: ReturnType<typeof createMockProcess>, code: number) {
+  proc.stdout.push(null); // end stream
+  proc.emit('close', code);
+}
+
+/** The deterministic per-session log path the engine passes via --log-file. */
+function logPathFor(session: InstanceType<typeof PersistentAgySession>): string {
+  return path.join(os.tmpdir(), `agy-${session.sessionId}.log`);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('PersistentAgySession', () => {
+  let mockProc: ReturnType<typeof createMockProcess>;
+  const tmpLogs: string[] = [];
+
+  beforeEach(() => {
+    mockProc = createMockProcess();
+    mockSpawn.mockReset();
+    mockSpawn.mockReturnValue(mockProc);
+  });
+
+  afterEach(() => {
+    for (const f of tmpLogs.splice(0)) {
+      try {
+        fs.unlinkSync(f);
+      } catch {
+        /* already gone */
+      }
+    }
+  });
+
+  // ─── start() ────────────────────────────────────────────────────────────
+
+  describe('start()', () => {
+    it('initializes session and emits ready', async () => {
+      const session = new PersistentAgySession({ name: 'test', cwd: '/tmp', permissionMode: 'default' });
+      const readyFn = vi.fn();
+      session.on('ready', readyFn);
+
+      await session.start();
+
+      expect(session.isReady).toBe(true);
+      expect(session.sessionId).toMatch(/^agy-/);
+      expect(readyFn).toHaveBeenCalled();
+    });
+  });
+
+  // ─── spawn flags ────────────────────────────────────────────────────────
+
+  describe('spawn flags', () => {
+    it('uses --dangerously-skip-permissions for bypassPermissions', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        model: 'gemini-3.5-flash',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(spawnArgs).toContain('-p');
+      expect(spawnArgs).toContain('hello');
+      expect(spawnArgs).toContain('--dangerously-skip-permissions');
+      expect(spawnArgs).toContain('--model');
+      expect(spawnArgs).toContain('gemini-3.5-flash');
+      expect(spawnArgs).toContain('--log-file');
+    });
+
+    it('uses --sandbox for default permissionMode', async () => {
+      const session = new PersistentAgySession({ name: 'test', cwd: '/tmp', permissionMode: 'default' });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(spawnArgs).toContain('--sandbox');
+      expect(spawnArgs).not.toContain('--dangerously-skip-permissions');
+    });
+
+    it('omits permission flags for other permission modes', async () => {
+      const session = new PersistentAgySession({ name: 'test', cwd: '/tmp', permissionMode: 'acceptEdits' });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(spawnArgs).not.toContain('--sandbox');
+      expect(spawnArgs).not.toContain('--dangerously-skip-permissions');
+    });
+
+    it('derives --print-timeout from the send timeout', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true, timeout: 60_000 });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      const idx = spawnArgs.indexOf('--print-timeout');
+      expect(idx).toBeGreaterThan(-1);
+      // 60s send timeout + 5s margin so the wrapper timer, not agy, decides
+      expect(spawnArgs[idx + 1]).toBe('65s');
+    });
+  });
+
+  // ─── conversation continuity ────────────────────────────────────────────
+
+  describe('conversation continuity', () => {
+    it('harvests conversation ID from the log and passes --conversation on the next send', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      // Turn 1: agy writes its log; the engine harvests the new conversation ID
+      const logFile = logPathFor(session);
+      tmpLogs.push(logFile);
+      const send1 = session.send('first turn', { waitForComplete: true });
+      setTimeout(() => {
+        fs.writeFileSync(
+          logFile,
+          'I0705 server.go:825] Created conversation 4ebc13c0-4cd3-4f59-b19d-2ee98ad883b2\n',
+        );
+        feedText(mockProc, 'STORED\n');
+        closeProc(mockProc, 0);
+      }, 10);
+      await send1;
+
+      expect(session.conversationId).toBe('4ebc13c0-4cd3-4f59-b19d-2ee98ad883b2');
+      expect(session.getStats().agyConversationId).toBe('4ebc13c0-4cd3-4f59-b19d-2ee98ad883b2');
+      const firstArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(firstArgs).not.toContain('--conversation');
+
+      // Turn 2: resume with the harvested ID
+      const proc2 = createMockProcess();
+      mockSpawn.mockReturnValue(proc2);
+      const send2 = session.send('second turn', { waitForComplete: true });
+      setTimeout(() => {
+        proc2.stdout.push(null);
+        proc2.emit('close', 0);
+      }, 10);
+      await send2;
+
+      const secondArgs = mockSpawn.mock.calls[1][1] as string[];
+      const idx = secondArgs.indexOf('--conversation');
+      expect(idx).toBeGreaterThan(-1);
+      expect(secondArgs[idx + 1]).toBe('4ebc13c0-4cd3-4f59-b19d-2ee98ad883b2');
+    });
+
+    it('seeds the conversation ID from resumeSessionId', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        resumeSessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello again', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      const idx = spawnArgs.indexOf('--conversation');
+      expect(idx).toBeGreaterThan(-1);
+      expect(spawnArgs[idx + 1]).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    });
+
+    it('keeps the existing ID when the log has no Created line (resumed turn)', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        resumeSessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      });
+      await session.start();
+
+      const logFile = logPathFor(session);
+      tmpLogs.push(logFile);
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => {
+        fs.writeFileSync(logFile, 'I0705 server.go:2215] GetConversationDetail: found conversation (active=true)\n');
+        closeProc(mockProc, 0);
+      }, 10);
+      await sendPromise;
+
+      expect(session.conversationId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    });
+  });
+
+  // ─── plain-text output ──────────────────────────────────────────────────
+
+  describe('plain-text output', () => {
+    it('accumulates stdout chunks and trims the trailing newline', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const chunks: string[] = [];
+      const sendPromise = session.send('hello', {
+        waitForComplete: true,
+        callbacks: { onText: (t: string) => chunks.push(t) },
+      });
+      setTimeout(() => {
+        feedText(mockProc, 'Hello ');
+        feedText(mockProc, 'world!\n');
+        closeProc(mockProc, 0);
+      }, 10);
+
+      const result = await sendPromise;
+      expect('text' in result && result.text).toBe('Hello world!');
+      expect(chunks.join('')).toBe('Hello world!\n');
+    });
+
+    it('estimates tokens since agy emits no usage data', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const sendPromise = session.send('a prompt message', { waitForComplete: true });
+      setTimeout(() => {
+        feedText(mockProc, 'some response text here\n');
+        closeProc(mockProc, 0);
+      }, 10);
+
+      await sendPromise;
+      const stats = session.getStats();
+      // Estimation: ~4 chars per token
+      expect(stats.tokensIn).toBeGreaterThan(0);
+      expect(stats.tokensOut).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── exit codes ─────────────────────────────────────────────────────────
+
+  describe('exit codes', () => {
+    it('rejects on non-zero exit', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 1), 10);
+
+      await expect(sendPromise).rejects.toThrow('Antigravity exited with code 1');
+    });
+  });
+
+  // ─── lifecycle ──────────────────────────────────────────────────────────
+
+  describe('lifecycle', () => {
+    it('stop() kills in-flight process and removes the log file', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const logFile = logPathFor(session);
+      fs.writeFileSync(logFile, 'leftover log\n');
+
+      session.send('hello', { waitForComplete: false });
+      session.stop();
+
+      expect(mockProc.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(session.isReady).toBe(false);
+      expect(fs.existsSync(logFile)).toBe(false);
+    });
+
+    it('compact() returns no-op message', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const result = await session.compact();
+      expect(result.text).toContain('does not support compaction');
+    });
+
+    it('getCost() uses gemini-3.5-flash pricing by default', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const cost = session.getCost();
+      expect(cost.model).toBe('gemini-3.5-flash');
+      expect(cost.pricing.inputPer1M).toBe(0.5);
+      expect(cost.pricing.outputPer1M).toBe(3);
+    });
+  });
+
+  // ─── stderr sanitization ────────────────────────────────────────────────
+
+  describe('stderr sanitization', () => {
+    it('redacts bearer tokens from stderr', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const logs: string[] = [];
+      session.on('log', (msg: string) => logs.push(msg));
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => {
+        mockProc.stderr.emit('data', Buffer.from('auth failed: Bearer ya29.secret-token not valid'));
+        closeProc(mockProc, 0);
+      }, 10);
+
+      await sendPromise;
+      expect(logs.some((l) => l.includes('Bearer ***'))).toBe(true);
+      expect(logs.some((l) => l.includes('ya29.secret-token'))).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -57,6 +57,8 @@ describe('lookupModel', () => {
       'codex-mini-latest',
       'gemini-3.1-pro-preview',
       'gemini-3-flash-preview',
+      'gemini-3.5-flash',
+      'gemini-3.1-pro',
       'gemini-2.5-pro',
       'gemini-2.5-flash',
       'composer-2',
@@ -94,12 +96,29 @@ describe('resolveEngineAndModel', () => {
       engine: 'gemini',
       model: 'gemini-3-flash-preview',
     });
+    expect(resolveEngineAndModel('gemini-3.5-flash')).toEqual({
+      engine: 'agy',
+      model: 'gemini-3.5-flash',
+    });
     expect(resolveEngineAndModel('composer-2')).toEqual({ engine: 'cursor', model: 'composer-2' });
   });
 
   it('resolves aliases to canonical id', () => {
     expect(resolveEngineAndModel('opus')).toEqual({ engine: 'claude', model: 'claude-opus-4-8' });
     expect(resolveEngineAndModel('gemini-flash')).toEqual({ engine: 'gemini', model: 'gemini-3-flash-preview' });
+    expect(resolveEngineAndModel('agy-pro')).toEqual({ engine: 'agy', model: 'gemini-3.1-pro' });
+  });
+
+  it('uses the agy/ prefix to force the Antigravity engine', () => {
+    expect(resolveEngineAndModel('agy/gemini-3.5-flash')).toEqual({
+      engine: 'agy',
+      model: 'gemini-3.5-flash',
+    });
+    expect(resolveEngineAndModel('agy/agy-pro')).toEqual({ engine: 'agy', model: 'gemini-3.1-pro' });
+    expect(resolveEngineAndModel('agy/claude-sonnet-5')).toEqual({
+      engine: 'agy',
+      model: 'claude-sonnet-5',
+    });
   });
 
   it('uses pattern fallback for unknown models', () => {
@@ -128,6 +147,7 @@ describe('resolveProvider', () => {
     expect(resolveProvider('anthropic/claude-opus-4-6').provider).toBe('anthropic');
     expect(resolveProvider('openai/gpt-5.4').provider).toBe('openai');
     expect(resolveProvider('google/gemini-3-flash-preview').provider).toBe('google');
+    expect(resolveProvider('agy/gemini-3.5-flash')).toEqual({ provider: 'google', apiModel: 'gemini-3.5-flash' });
     expect(resolveProvider('openai-codex/gpt-5.4').provider).toBe('openai');
   });
 

--- a/src/__tests__/session-manager.test.ts
+++ b/src/__tests__/session-manager.test.ts
@@ -22,6 +22,7 @@ import type {
 
 class MockSession extends EventEmitter implements ISession {
   sessionId?: string;
+  conversationId?: string;
   private _isReady = true;
   private _isPaused = false;
   private _isBusy = false;
@@ -141,6 +142,7 @@ class MockSession extends EventEmitter implements ISession {
 // ─── Mock Factory ─────────────────────────────────────────────────────────
 
 let mockSessions: MockSession[] = [];
+let createdConfigs: SessionConfig[] = [];
 
 /**
  * We intercept the _createSession private method to inject MockSession
@@ -150,7 +152,9 @@ function patchCreateSession(manager: InstanceType<typeof SessionManager>): void 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (manager as any)._createSession = (_engine: string, _config: SessionConfig): ISession => {
     const mock = new MockSession();
+    if (_engine === 'agy' && _config.resumeSessionId) mock.conversationId = _config.resumeSessionId;
     mockSessions.push(mock);
+    createdConfigs.push(_config);
     return mock;
   };
 }
@@ -232,6 +236,7 @@ describe('SessionManager', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     mockSessions = [];
+    createdConfigs = [];
     mgr = createManager();
   });
 
@@ -1131,6 +1136,18 @@ describe('SessionManager', () => {
       // The session should have been recreated
       expect(mockSessions.length).toBe(2); // original + new
     });
+
+    it('uses the agy conversation UUID, not the synthetic session ID, when switching models', async () => {
+      await mgr.startSession({ name: 'agy-switch', cwd: '/tmp', engine: 'agy', model: 'gemini-3.5-flash' });
+      lastMock().conversationId = '11111111-2222-3333-4444-555555555555';
+      lastMock().setBusy(false);
+
+      await mgr.sendMessage('agy-switch', 'hello');
+      await mgr.switchModel('agy-switch', 'agy-pro');
+
+      expect(createdConfigs[1].resumeSessionId).toBe('11111111-2222-3333-4444-555555555555');
+      expect(createdConfigs[1].resumeSessionId).not.toMatch(/^mock-session-/);
+    });
   });
 
   // ─── updateTools ────────────────────────────────────────────────────
@@ -1185,6 +1202,18 @@ describe('SessionManager', () => {
       });
       expect(info.name).toBe('tools-merge');
     });
+
+    it('uses the agy conversation UUID, not the synthetic session ID, when updating tools', async () => {
+      await mgr.startSession({ name: 'agy-tools', cwd: '/tmp', engine: 'agy', model: 'gemini-3.5-flash' });
+      lastMock().conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+      lastMock().setBusy(false);
+
+      await mgr.sendMessage('agy-tools', 'hello');
+      await mgr.updateTools('agy-tools', { allowedTools: ['Read'] });
+
+      expect(createdConfigs[1].resumeSessionId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+      expect(createdConfigs[1].resumeSessionId).not.toMatch(/^mock-session-/);
+    });
   });
 
   // ─── Persisted Sessions ─────────────────────────────────────────────
@@ -1207,6 +1236,20 @@ describe('SessionManager', () => {
 
       await mgr.stopSession('persist-remove');
       expect(mgr.listPersistedSessions().find((p) => p.name === 'persist-remove')).toBeUndefined();
+    });
+
+    it('persists the agy conversation UUID after first send and never the synthetic session ID', async () => {
+      const info = await mgr.startSession({ name: 'agy-persist', cwd: '/tmp', engine: 'agy' });
+      expect(info.claudeSessionId).toBeUndefined();
+      expect(mgr.listPersistedSessions().find((p) => p.name === 'agy-persist')).toBeUndefined();
+
+      lastMock().conversationId = '99999999-8888-7777-6666-555555555555';
+      const result = await mgr.sendMessage('agy-persist', 'hello');
+
+      expect(result.sessionId).toBe('99999999-8888-7777-6666-555555555555');
+      const entry = mgr.listPersistedSessions().find((p) => p.name === 'agy-persist');
+      expect(entry?.claudeSessionId).toBe('99999999-8888-7777-6666-555555555555');
+      expect(entry?.claudeSessionId).not.toMatch(/^mock-session-/);
     });
   });
 

--- a/src/agy-conversation.ts
+++ b/src/agy-conversation.ts
@@ -1,0 +1,12 @@
+const AGY_CONVERSATION_ID_SOURCE = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+const AGY_CONVERSATION_ID_RE = new RegExp(`^${AGY_CONVERSATION_ID_SOURCE}$`, 'i');
+const AGY_CREATED_CONVERSATION_RE = new RegExp(`Created conversation (${AGY_CONVERSATION_ID_SOURCE})`, 'i');
+
+export function isAgyConversationId(value: string | undefined): value is string {
+  return !!value && AGY_CONVERSATION_ID_RE.test(value);
+}
+
+export function extractCreatedAgyConversationId(log: string): string | undefined {
+  return log.match(AGY_CREATED_CONVERSATION_RE)?.[1];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,14 @@ import { SessionManager } from './session-manager.js';
 import { createProxyHandler } from './proxy/handler.js';
 import { EmbeddedServer } from './embedded-server.js';
 import { sanitizeCwd, validateRegex } from './validation.js';
-import type { PluginConfig, EffortLevel, CouncilConfig, AgentPersona, EngineType } from './types.js';
+import {
+  ENGINE_TYPES,
+  type PluginConfig,
+  type EffortLevel,
+  type CouncilConfig,
+  type AgentPersona,
+  type EngineType,
+} from './types.js';
 import type { FanoutConfig } from './fanout.js';
 
 // ─── Standalone Export ───────────────────────────────────────────────────────
@@ -154,7 +161,7 @@ const plugin = {
           cwd: { type: 'string', description: 'Working directory' },
           engine: {
             type: 'string',
-            enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode', 'custom'],
+            enum: ENGINE_TYPES,
             description:
               'Engine to use (default: claude). codex = `codex exec` per send (no /goal). codex-app = long-running `codex app-server` with /goal support. agy = Google Antigravity CLI (Gemini CLI successor; plain-text output, tokens estimated, conversation resume handled automatically). opencode = sst/opencode CLI (provider-agnostic; pass model as `provider/model`). Use "custom" with customEngine config for any CLI.',
           },
@@ -1023,7 +1030,7 @@ const plugin = {
                 name: { type: 'string', minLength: 1, description: 'Unique label (forms the session name).' },
                 engine: {
                   type: 'string',
-                  enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode', 'custom'],
+                  enum: ENGINE_TYPES,
                 },
                 model: { type: 'string' },
                 prompt: { type: 'string' },
@@ -1039,7 +1046,7 @@ const plugin = {
           synthesisModel: { type: 'string', description: 'Model for the synthesis pass.' },
           synthesisEngine: {
             type: 'string',
-            enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode', 'custom'],
+            enum: ENGINE_TYPES,
             description: 'Engine for the synthesis pass (default claude).',
           },
           agentTimeoutMs: { type: 'number', description: 'Per-agent timeout in ms (default 600000).' },
@@ -1111,7 +1118,7 @@ const plugin = {
                 persona: { type: 'string', description: 'Agent personality/expertise description' },
                 engine: {
                   type: 'string',
-                  enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode', 'custom'],
+                  enum: ENGINE_TYPES,
                   description: 'Engine (default: claude). Use "custom" with customEngine for any CLI.',
                 },
                 model: { type: 'string', description: 'Model to use' },
@@ -1398,7 +1405,10 @@ const plugin = {
           focus: { type: 'string', description: 'Review focus area (default: bugs + security + quality)' },
           engines: {
             type: 'array',
-            items: { type: 'string', enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode'] },
+            // 'custom' is deliberately excluded: ultrareview spawns reviewer
+            // sessions without a customEngine config, so a custom reviewer
+            // would fail at session start.
+            items: { type: 'string', enum: ENGINE_TYPES.filter((e) => e !== 'custom') },
             description:
               'Engines to round-robin reviewers across (default ["claude"]). Reviewers fan out in parallel; per-agent failures are isolated.',
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export { PersistentClaudeSession } from './persistent-session.js';
 export { BaseOneShotSession, type OneShotEngineConfig } from './base-oneshot-session.js';
 export { PersistentCodexSession } from './persistent-codex-session.js';
 export { PersistentGeminiSession } from './persistent-gemini-session.js';
+export { PersistentAgySession } from './persistent-agy-session.js';
 export { PersistentCursorSession } from './persistent-cursor-session.js';
 export { PersistentOpencodeSession } from './persistent-opencode-session.js';
 export { PersistentCustomSession } from './persistent-custom-session.js';
@@ -145,7 +146,7 @@ const plugin = {
     api.registerTool({
       name: 'session_start',
       description:
-        'Start a persistent coding session. Supports multiple engines: claude (default) for Claude Code CLI, codex for OpenAI Codex CLI, gemini for Google Gemini CLI, cursor for Cursor Agent CLI, opencode for sst/opencode CLI, or custom for any user-configured coding agent CLI.',
+        'Start a persistent coding session. Supports multiple engines: claude (default) for Claude Code CLI, codex for OpenAI Codex CLI, gemini for Google Gemini CLI, agy for Google Antigravity CLI, cursor for Cursor Agent CLI, opencode for sst/opencode CLI, or custom for any user-configured coding agent CLI.',
       parameters: {
         type: 'object',
         properties: {
@@ -153,9 +154,9 @@ const plugin = {
           cwd: { type: 'string', description: 'Working directory' },
           engine: {
             type: 'string',
-            enum: ['claude', 'codex', 'codex-app', 'gemini', 'cursor', 'opencode', 'custom'],
+            enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode', 'custom'],
             description:
-              'Engine to use (default: claude). codex = `codex exec` per send (no /goal). codex-app = long-running `codex app-server` with /goal support. opencode = sst/opencode CLI (provider-agnostic; pass model as `provider/model`). Use "custom" with customEngine config for any CLI.',
+              'Engine to use (default: claude). codex = `codex exec` per send (no /goal). codex-app = long-running `codex app-server` with /goal support. agy = Google Antigravity CLI (Gemini CLI successor; plain-text output, tokens estimated, conversation resume handled automatically). opencode = sst/opencode CLI (provider-agnostic; pass model as `provider/model`). Use "custom" with customEngine config for any CLI.',
           },
           model: { type: 'string', description: 'Model to use (opus, sonnet, haiku, gemini-pro, o4-mini, etc.)' },
           permissionMode: {
@@ -1022,7 +1023,7 @@ const plugin = {
                 name: { type: 'string', minLength: 1, description: 'Unique label (forms the session name).' },
                 engine: {
                   type: 'string',
-                  enum: ['claude', 'codex', 'codex-app', 'gemini', 'cursor', 'opencode', 'custom'],
+                  enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode', 'custom'],
                 },
                 model: { type: 'string' },
                 prompt: { type: 'string' },
@@ -1038,7 +1039,7 @@ const plugin = {
           synthesisModel: { type: 'string', description: 'Model for the synthesis pass.' },
           synthesisEngine: {
             type: 'string',
-            enum: ['claude', 'codex', 'codex-app', 'gemini', 'cursor', 'opencode', 'custom'],
+            enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode', 'custom'],
             description: 'Engine for the synthesis pass (default claude).',
           },
           agentTimeoutMs: { type: 'number', description: 'Per-agent timeout in ms (default 600000).' },
@@ -1110,7 +1111,7 @@ const plugin = {
                 persona: { type: 'string', description: 'Agent personality/expertise description' },
                 engine: {
                   type: 'string',
-                  enum: ['claude', 'codex', 'codex-app', 'gemini', 'cursor', 'opencode', 'custom'],
+                  enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode', 'custom'],
                   description: 'Engine (default: claude). Use "custom" with customEngine for any CLI.',
                 },
                 model: { type: 'string', description: 'Model to use' },
@@ -1397,7 +1398,7 @@ const plugin = {
           focus: { type: 'string', description: 'Review focus area (default: bugs + security + quality)' },
           engines: {
             type: 'array',
-            items: { type: 'string', enum: ['claude', 'codex', 'codex-app', 'gemini', 'cursor', 'opencode'] },
+            items: { type: 'string', enum: ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode'] },
             description:
               'Engines to round-robin reviewers across (default ["claude"]). Reviewers fan out in parallel; per-agent failures are isolated.',
           },

--- a/src/models.ts
+++ b/src/models.ts
@@ -292,6 +292,18 @@ export function resolveAlias(alias: string): string {
 
 /** Resolve model string to engine + canonical model. Pattern fallback for unknown models. */
 export function resolveEngineAndModel(model: string): { engine: EngineType; model: string } {
+  // The `agy/` vendor prefix pins the Antigravity engine (mirroring the strip
+  // lists in resolveProvider/getContextWindow/getModelPricing). It must win
+  // over both the registry and the pattern heuristics: agy proxies Claude and
+  // GPT-OSS models that are registered to other engines, and a bare
+  // `gemini-*` heuristic would route `agy/gemini-3.5-flash` to the gemini
+  // engine — the opposite of the prefix's intent. Other vendor prefixes are
+  // deliberately NOT stripped here: prefixed strings fall through to the
+  // claude engine, which proxies them to the gateway.
+  if (model.startsWith('agy/')) {
+    return { engine: 'agy', model: resolveAlias(model.slice('agy/'.length)) };
+  }
+
   // 1. Exact match (id or alias)
   const known = lookupModel(model);
   if (known) return { engine: known.engine, model: known.id };

--- a/src/models.ts
+++ b/src/models.ts
@@ -184,6 +184,32 @@ const MODELS: ModelDef[] = [
     contextWindow: 1_000_000,
   },
 
+  // ── Google Antigravity (agy) ───────────────────────────────────────────
+  // Antigravity CLI is Gemini CLI's successor (consumer Gemini CLI stopped
+  // serving 2026-06-18). Consumer agy auth is subscription-based with no
+  // per-token billing, and agy emits no usage data, so token counts for this
+  // engine are ESTIMATED. Pricing mirrors Gemini API list rates so costUsd
+  // approximates equivalent API value; use overrideModelPricing() to zero it
+  // out for subscription accounting. Slugs verified against agy 1.0.16
+  // (`agy models`); agy also proxies Claude/GPT-OSS models, passed through
+  // unregistered. Unknown slugs silently fall back to agy's default model.
+  {
+    id: 'gemini-3.5-flash',
+    engine: 'agy',
+    provider: 'google',
+    pricing: { input: 0.5, output: 3 },
+    aliases: ['agy-flash'],
+    contextWindow: 1_000_000,
+  },
+  {
+    id: 'gemini-3.1-pro',
+    engine: 'agy',
+    provider: 'google',
+    pricing: { input: 2, output: 12 },
+    aliases: ['agy-pro'],
+    contextWindow: 1_000_000,
+  },
+
   // ── Google Gemini 2.5 (stable) ─────────────────────────────────────────
   {
     id: 'gemini-2.5-pro',
@@ -285,7 +311,7 @@ export function resolveEngineAndModel(model: string): { engine: EngineType; mode
 export function resolveProvider(model: string): { provider: ProviderName; apiModel: string } {
   // Strip vendor prefixes
   let clean = model;
-  for (const prefix of ['anthropic/', 'openai/', 'openai-codex/', 'gemini/', 'google/', 'cursor/']) {
+  for (const prefix of ['anthropic/', 'openai/', 'openai-codex/', 'gemini/', 'google/', 'agy/', 'cursor/']) {
     if (clean.startsWith(prefix)) {
       clean = clean.slice(prefix.length);
       break;
@@ -322,7 +348,7 @@ export function resolveProvider(model: string): { provider: ProviderName; apiMod
 
 /** Get context window size for a model. Returns 200k default for unknown models. */
 export function getContextWindow(model: string): number {
-  const clean = model.replace(/^(anthropic|openai|openai-codex|google|gemini|cursor)\//g, '');
+  const clean = model.replace(/^(anthropic|openai|openai-codex|google|gemini|agy|cursor)\//g, '');
   const known = lookupModel(clean);
   return known?.contextWindow ?? 200_000;
 }
@@ -330,7 +356,7 @@ export function getContextWindow(model: string): number {
 /** Get pricing for a model. Falls back to sonnet pricing for unknown models. */
 export function getModelPricing(model?: string, defaultModel = 'claude-sonnet-4-6'): ModelPricing {
   if (!model) return lookupModel(defaultModel)?.pricing ?? { input: 0, output: 0 };
-  const clean = model.replace(/^(anthropic|openai|openai-codex|google|gemini|cursor)\//g, '');
+  const clean = model.replace(/^(anthropic|openai|openai-codex|google|gemini|agy|cursor)\//g, '');
   // Check overrides first
   const override = _pricingOverrides.get(clean);
   if (override) return override;

--- a/src/persistent-agy-session.ts
+++ b/src/persistent-agy-session.ts
@@ -28,6 +28,8 @@ import * as path from 'node:path';
 
 import type { SessionConfig, SessionSendOptions, StreamEvent, TurnResult } from './types.js';
 import { estimateTokens } from './models.js';
+import { sanitizeSecrets } from './sanitize.js';
+import { extractCreatedAgyConversationId, isAgyConversationId } from './agy-conversation.js';
 import { SESSION_EVENT } from './constants.js';
 import { BaseOneShotSession } from './base-oneshot-session.js';
 
@@ -48,7 +50,11 @@ export class PersistentAgySession extends BaseOneShotSession {
       supportsCachedTokens: false,
       engineDisplayName: 'Antigravity',
     });
-    if (config.resumeSessionId) this.agyConversationId = config.resumeSessionId;
+    // Non-UUID ids (synthetic session ids from persistence/restart paths) are
+    // ignored: starting a fresh conversation beats resuming a broken one.
+    if (isAgyConversationId(config.resumeSessionId)) {
+      this.agyConversationId = config.resumeSessionId;
+    }
   }
 
   /** Expose the captured conversation ID for resume tooling and stats overlay. */
@@ -86,7 +92,12 @@ export class PersistentAgySession extends BaseOneShotSession {
       args.push('--sandbox');
     }
 
-    if (this.options.model) args.push('--model', this.options.model);
+    // Use the SessionManager-resolved model when available so documented
+    // aliases (agy-pro → gemini-3.1-pro) do not silently fall back to agy's
+    // default model.
+    const configuredModel = this.options.resolvedModel || this.options.model;
+    const model = configuredModel ? this.resolveModel(configuredModel.replace(/^agy\//, '')) : undefined;
+    if (model) args.push('--model', model);
     if (this.agyConversationId) args.push('--conversation', this.agyConversationId);
 
     // agy enforces its own print-mode timeout (default 5m). Derive it from the
@@ -102,13 +113,29 @@ export class PersistentAgySession extends BaseOneShotSession {
    * existing ID is never overwritten by a miss.
    */
   private _harvestConversationId(): void {
+    // Once harvested (or seeded) the ID is final for the life of the session
+    // — skip the synchronous whole-log re-read on every later turn.
+    if (this.agyConversationId) return;
     try {
       const log = fs.readFileSync(this._logFile, 'utf8');
-      const created = log.match(/Created conversation ([0-9a-f-]{8,})/i);
-      if (created) this.agyConversationId = created[1];
+      this.agyConversationId = extractCreatedAgyConversationId(log);
     } catch {
-      // Log file missing (agy failed before logging) — keep any existing ID
+      // Log file missing — agy failed before logging anything
     }
+    if (!this.agyConversationId) {
+      // Without an ID every later send silently starts a fresh conversation.
+      // Make that observable — if this fires on every turn, agy most likely
+      // reworded its log line and the harvest regex needs updating.
+      this._warnHarvestMiss();
+    }
+  }
+
+  private _warnHarvestMiss(): void {
+    if (this._stats.turns !== 0) return;
+    this.emit(
+      SESSION_EVENT.LOG,
+      '[agy] no conversation ID found in log after turn — resume unavailable; the next send starts a fresh conversation',
+    );
   }
 
   protected _run(message: string, options: SessionSendOptions): Promise<TurnResult> {
@@ -148,10 +175,7 @@ export class PersistentAgySession extends BaseOneShotSession {
       });
 
       proc.stderr?.on('data', (data: Buffer) => {
-        const sanitized = data
-          .toString()
-          .replace(/Bearer [a-zA-Z0-9._-]+/g, 'Bearer ***')
-          .replace(/(api[_-]?key["':= ]+)[a-zA-Z0-9_-]+/gi, '$1***');
+        const sanitized = sanitizeSecrets(data.toString());
         stderr += sanitized;
         this.emit(SESSION_EVENT.LOG, `[agy-stderr] ${sanitized}`);
       });
@@ -159,10 +183,17 @@ export class PersistentAgySession extends BaseOneShotSession {
       proc.on('close', (code) => {
         clearTimeout(timer);
         this.currentProc = null;
+
+        // Harvest BEFORE the settled check: a turn that hit the wrapper
+        // timeout has already rejected (settled), but agy may still have
+        // logged `Created conversation <uuid>` before being killed. Skipping
+        // the harvest here would lose the ID permanently and every later
+        // send would silently start a fresh conversation.
+        this._harvestConversationId();
+
         if (settled) return;
         settled = true;
 
-        this._harvestConversationId();
         this._recordTurnComplete();
 
         const text = resultText.replace(/\n$/, '');

--- a/src/persistent-agy-session.ts
+++ b/src/persistent-agy-session.ts
@@ -1,0 +1,220 @@
+/**
+ * Persistent Antigravity Session — wraps Google `agy` CLI (Antigravity CLI)
+ *
+ * Antigravity CLI is Google's successor to Gemini CLI (consumer tiers of
+ * Gemini CLI stopped serving 2026-06-18). Like Codex/Gemini, each send()
+ * spawns a new `agy` process in print mode.
+ *
+ * agy (verified against 1.0.16) has NO structured output mode — stdout is
+ * the plain response text. Two behaviors make this a real engine rather
+ * than a custom-engine recipe:
+ *
+ *   - Conversation continuity: agy logs `Created conversation <uuid>` to
+ *     its log file. We pass a private --log-file per session, harvest the
+ *     ID after the first send, and pass `--conversation <id>` on subsequent
+ *     sends — true multi-turn context, like Codex thread resume.
+ *   - Timeout coherence: agy enforces its own --print-timeout (default 5m);
+ *     we derive it from the send timeout so the two never disagree.
+ *
+ * Token usage is estimated (~4 chars/token) since agy emits no usage data.
+ * Unknown --model values do not error — agy silently falls back to its
+ * default model (verified empirically on 1.0.16).
+ */
+
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { SessionConfig, SessionSendOptions, StreamEvent, TurnResult } from './types.js';
+import { estimateTokens } from './models.js';
+import { SESSION_EVENT } from './constants.js';
+import { BaseOneShotSession } from './base-oneshot-session.js';
+
+// ─── PersistentAgySession ───────────────────────────────────────────────────
+
+export class PersistentAgySession extends BaseOneShotSession {
+  /**
+   * Antigravity conversation ID for this session. Captured from the agy log
+   * file after the first turn, then reused via `--conversation <id>` so the
+   * model sees prior turns. Seeded from `resumeSessionId` when provided.
+   */
+  private agyConversationId: string | undefined;
+
+  constructor(config: SessionConfig, agyBin?: string) {
+    super(config, agyBin || process.env.AGY_BIN || 'agy', {
+      enginePrefix: 'agy',
+      defaultModel: 'gemini-3.5-flash',
+      supportsCachedTokens: false,
+      engineDisplayName: 'Antigravity',
+    });
+    if (config.resumeSessionId) this.agyConversationId = config.resumeSessionId;
+  }
+
+  /** Expose the captured conversation ID for resume tooling and stats overlay. */
+  get conversationId(): string | undefined {
+    return this.agyConversationId;
+  }
+
+  /**
+   * One log file per session (agy re-creates it each run; the harvest regex
+   * only needs the latest `Created conversation` line). Deterministic path so
+   * stop() can clean it up.
+   */
+  private get _logFile(): string {
+    return path.join(os.tmpdir(), `agy-${this.sessionId}.log`);
+  }
+
+  /**
+   * Build the agy spawn args for this turn.
+   *
+   * First turn:    `agy -p <msg> --log-file <tmp> [--sandbox|--dangerously-skip-permissions] [--model M] --print-timeout Ns`
+   * Resume turns:  same + `--conversation <id>`
+   */
+  private _buildArgs(message: string, timeoutMs: number): string[] {
+    const args: string[] = ['-p', message, '--log-file', this._logFile];
+
+    // Permission mode. agy has no fine-grained permission flags (verified on
+    // 1.0.16): bypass maps to --dangerously-skip-permissions, `default` maps
+    // to --sandbox (terminal-restricted). Other modes run agy's own default
+    // approval behavior — which blocks on unapproved tools in print mode, so
+    // bypassPermissions (the SessionConfig default) is the practical choice
+    // for headless work.
+    if (this.options.permissionMode === 'bypassPermissions' || this.options.dangerouslySkipPermissions) {
+      args.push('--dangerously-skip-permissions');
+    } else if (this.options.permissionMode === 'default') {
+      args.push('--sandbox');
+    }
+
+    if (this.options.model) args.push('--model', this.options.model);
+    if (this.agyConversationId) args.push('--conversation', this.agyConversationId);
+
+    // agy enforces its own print-mode timeout (default 5m). Derive it from the
+    // send timeout (+5s margin) so our timer, not agy's, decides the outcome.
+    args.push('--print-timeout', `${Math.ceil(timeoutMs / 1000) + 5}s`);
+
+    return args;
+  }
+
+  /**
+   * Harvest the conversation ID from the agy log file. New conversations log
+   * `Created conversation <uuid>`; resumed ones only log lookups, so an
+   * existing ID is never overwritten by a miss.
+   */
+  private _harvestConversationId(): void {
+    try {
+      const log = fs.readFileSync(this._logFile, 'utf8');
+      const created = log.match(/Created conversation ([0-9a-f-]{8,})/i);
+      if (created) this.agyConversationId = created[1];
+    } catch {
+      // Log file missing (agy failed before logging) — keep any existing ID
+    }
+  }
+
+  protected _run(message: string, options: SessionSendOptions): Promise<TurnResult> {
+    const timeout = options.timeout || 300_000;
+    const args = this._buildArgs(message, timeout);
+
+    return new Promise<TurnResult>((resolve, reject) => {
+      let resultText = '';
+      let stderr = '';
+      let settled = false;
+
+      const proc = spawn(this.engineBin, args, {
+        cwd: this.options.cwd,
+        env: { ...process.env },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      this.currentProc = proc;
+
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          proc.kill('SIGTERM');
+          reject(new Error('Timeout waiting for Antigravity response'));
+        }
+      }, timeout);
+
+      // Plain-text stdout — forward chunks as streaming text
+      proc.stdout?.on('data', (data: Buffer) => {
+        const chunk = data.toString();
+        resultText += chunk;
+        try {
+          options.callbacks?.onText?.(chunk);
+        } catch {
+          // User callback error
+        }
+        this.emit(SESSION_EVENT.TEXT, chunk);
+      });
+
+      proc.stderr?.on('data', (data: Buffer) => {
+        const sanitized = data
+          .toString()
+          .replace(/Bearer [a-zA-Z0-9._-]+/g, 'Bearer ***')
+          .replace(/(api[_-]?key["':= ]+)[a-zA-Z0-9_-]+/gi, '$1***');
+        stderr += sanitized;
+        this.emit(SESSION_EVENT.LOG, `[agy-stderr] ${sanitized}`);
+      });
+
+      proc.on('close', (code) => {
+        clearTimeout(timer);
+        this.currentProc = null;
+        if (settled) return;
+        settled = true;
+
+        this._harvestConversationId();
+        this._recordTurnComplete();
+
+        const text = resultText.replace(/\n$/, '');
+
+        // No usage events exist in agy — always estimate
+        if (text.length > 0 || code === 0) {
+          this._stats.tokensIn += estimateTokens(message);
+          this._stats.tokensOut += estimateTokens(text);
+          this._updateCost();
+        }
+
+        this._addHistory({ text, code });
+
+        const event: StreamEvent = {
+          type: 'result',
+          result: text,
+          stop_reason: code === 0 ? 'end_turn' : 'error',
+        };
+
+        this.emit(SESSION_EVENT.RESULT, event);
+        this.emit(SESSION_EVENT.TURN_COMPLETE, event);
+
+        if (code !== 0) {
+          reject(new Error(stderr || `Antigravity exited with code ${code}`));
+        } else {
+          resolve({ text, event });
+        }
+      });
+
+      proc.on('error', (err) => {
+        clearTimeout(timer);
+        if (!settled) {
+          settled = true;
+          reject(err);
+        }
+      });
+    });
+  }
+
+  /** Clean up the per-session log file along with the base teardown. */
+  stop(): void {
+    super.stop();
+    try {
+      fs.unlinkSync(this._logFile);
+    } catch {
+      // Never created, or already gone
+    }
+  }
+
+  /** Override getStats to expose the captured conversation ID. */
+  getStats(): ReturnType<BaseOneShotSession['getStats']> {
+    const base = super.getStats();
+    return { ...base, agyConversationId: this.agyConversationId };
+  }
+}

--- a/src/persistent-cursor-session.ts
+++ b/src/persistent-cursor-session.ts
@@ -16,6 +16,7 @@ import * as readline from 'node:readline';
 
 import type { SessionConfig, SessionSendOptions, StreamEvent, TurnResult } from './types.js';
 import { estimateTokens } from './models.js';
+import { sanitizeSecrets } from './sanitize.js';
 import { SESSION_EVENT } from './constants.js';
 import { BaseOneShotSession } from './base-oneshot-session.js';
 
@@ -101,10 +102,7 @@ export class PersistentCursorSession extends BaseOneShotSession {
       });
 
       proc.stderr?.on('data', (data: Buffer) => {
-        const sanitized = data
-          .toString()
-          .replace(/CURSOR_API_KEY=[^\s]+/g, 'CURSOR_API_KEY=***')
-          .replace(/Bearer [a-zA-Z0-9_-]+/g, 'Bearer ***');
+        const sanitized = sanitizeSecrets(data.toString());
         stderr += sanitized;
         this.emit(SESSION_EVENT.LOG, `[cursor-stderr] ${sanitized}`);
       });

--- a/src/persistent-custom-session.ts
+++ b/src/persistent-custom-session.ts
@@ -18,7 +18,6 @@
 import { spawn, ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import * as readline from 'node:readline';
-import RE2 from 're2';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -36,6 +35,7 @@ import {
   getModelPricing as _getModelPricingBase,
 } from './types.js';
 import { resolveAlias, estimateTokens } from './models.js';
+import { buildSanitizer } from './sanitize.js';
 
 import {
   CONTEXT_HIGH_THRESHOLD,
@@ -66,38 +66,6 @@ function resolveBin(engineConfig: CustomEngineConfig): string {
     if (envVal) return envVal;
   }
   return engineConfig.bin;
-}
-
-/** Build sanitizer function from config patterns + common defaults */
-function buildSanitizer(engineConfig: CustomEngineConfig): (text: string) => string {
-  const patterns: Array<{ re: RegExp; replacement: string }> = [
-    // Always sanitize Bearer tokens and common API key patterns
-    { re: /Bearer [a-zA-Z0-9_-]+/g, replacement: 'Bearer ***' },
-    { re: /sk-[a-zA-Z0-9_-]{10,}/g, replacement: 'sk-***' },
-  ];
-  if (engineConfig.sanitizePatterns) {
-    for (const p of engineConfig.sanitizePatterns) {
-      try {
-        // RE2 runs in linear time and never backtracks, so a user-supplied
-        // sanitize pattern cannot trigger ReDoS on attacker-influenced output.
-        patterns.push({ re: new RE2(p, 'g') as unknown as RegExp, replacement: '***' });
-      } catch (err) {
-        // A silently-dropped sanitize pattern means secrets stop being redacted
-        // — make it visible so the operator fixes the typo.
-        console.warn(
-          `[custom-session:${engineConfig.name}] ignoring invalid sanitizePattern ${JSON.stringify(p)}: ${(err as Error).message}`,
-        );
-      }
-    }
-  }
-  return (text: string) => {
-    let result = text;
-    for (const { re, replacement } of patterns) {
-      re.lastIndex = 0;
-      result = result.replace(re, replacement);
-    }
-    return result;
-  };
 }
 
 // ─── PersistentCustomSession ───────────────────────────────────────────────
@@ -145,7 +113,10 @@ export class PersistentCustomSession extends EventEmitter implements ISession {
     }
     this.engineConfig = config.customEngine;
     this.engineBin = resolveBin(this.engineConfig);
-    this.sanitize = buildSanitizer(this.engineConfig);
+    this.sanitize = buildSanitizer({
+      extraPatterns: this.engineConfig.sanitizePatterns,
+      label: `custom-session:${this.engineConfig.name}`,
+    });
     this.options = {
       ...config,
       permissionMode: config.permissionMode || 'acceptEdits',

--- a/src/persistent-gemini-session.ts
+++ b/src/persistent-gemini-session.ts
@@ -16,6 +16,7 @@ import * as readline from 'node:readline';
 
 import type { SessionConfig, SessionSendOptions, StreamEvent, TurnResult } from './types.js';
 import { estimateTokens } from './models.js';
+import { sanitizeSecrets } from './sanitize.js';
 import { SESSION_EVENT } from './constants.js';
 import { BaseOneShotSession } from './base-oneshot-session.js';
 
@@ -107,10 +108,7 @@ export class PersistentGeminiSession extends BaseOneShotSession {
       });
 
       proc.stderr?.on('data', (data: Buffer) => {
-        const sanitized = data
-          .toString()
-          .replace(/GEMINI_API_KEY=[^\s]+/g, 'GEMINI_API_KEY=***')
-          .replace(/Bearer [a-zA-Z0-9_-]+/g, 'Bearer ***');
+        const sanitized = sanitizeSecrets(data.toString());
         stderr += sanitized;
         this.emit(SESSION_EVENT.LOG, `[gemini-stderr] ${sanitized}`);
       });

--- a/src/persistent-opencode-session.ts
+++ b/src/persistent-opencode-session.ts
@@ -38,6 +38,7 @@ import * as readline from 'node:readline';
 
 import type { SessionConfig, SessionSendOptions, StreamEvent, TurnResult } from './types.js';
 import { estimateTokens } from './models.js';
+import { sanitizeSecrets } from './sanitize.js';
 import { SESSION_EVENT } from './constants.js';
 import { BaseOneShotSession } from './base-oneshot-session.js';
 
@@ -141,12 +142,7 @@ export class PersistentOpencodeSession extends BaseOneShotSession {
       });
 
       proc.stderr?.on('data', (data: Buffer) => {
-        const sanitized = data
-          .toString()
-          .replace(/OPENCODE_API_KEY=[^\s]+/g, 'OPENCODE_API_KEY=***')
-          .replace(/ANTHROPIC_API_KEY=[^\s]+/g, 'ANTHROPIC_API_KEY=***')
-          .replace(/OPENAI_API_KEY=[^\s]+/g, 'OPENAI_API_KEY=***')
-          .replace(/Bearer [a-zA-Z0-9_-]+/g, 'Bearer ***');
+        const sanitized = sanitizeSecrets(data.toString());
         stderr += sanitized;
         this.emit(SESSION_EVENT.LOG, `[opencode-stderr] ${sanitized}`);
       });

--- a/src/persistent-session.ts
+++ b/src/persistent-session.ts
@@ -25,6 +25,7 @@ import {
   getModelPricing,
 } from './types.js';
 import { resolveAlias, getContextWindow, isClaudeModel } from './models.js';
+import { sanitizeSecrets } from './sanitize.js';
 
 import {
   CONTEXT_HIGH_THRESHOLD,
@@ -344,14 +345,7 @@ export class PersistentClaudeSession extends EventEmitter implements ISession {
     });
 
     this.proc.stderr?.on('data', (data: Buffer) => {
-      const sanitized = data
-        .toString()
-        .replace(/sk-[a-zA-Z0-9_-]{10,}/g, 'sk-***')
-        .replace(/ANTHROPIC_API_KEY=[^\s]+/g, 'ANTHROPIC_API_KEY=***')
-        .replace(/OPENAI_API_KEY=[^\s]+/g, 'OPENAI_API_KEY=***')
-        .replace(/GEMINI_API_KEY=[^\s]+/g, 'GEMINI_API_KEY=***')
-        .replace(/Bearer [a-zA-Z0-9_-]+/g, 'Bearer ***');
-      this.emit(SESSION_EVENT.LOG, `[stderr] ${sanitized}`);
+      this.emit(SESSION_EVENT.LOG, `[stderr] ${sanitizeSecrets(data.toString())}`);
     });
 
     this.proc.on('close', (code) => {

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,0 +1,65 @@
+import RE2 from 're2';
+
+/**
+ * Shared stderr secret redaction.
+ *
+ * Every engine pipes CLI stderr into session LOG events, and failing CLIs
+ * routinely dump auth headers or env vars there. These patterns used to be
+ * hand-copied per engine (claude, gemini, cursor, opencode, custom — each a
+ * slightly different subset), which meant every new engine grew another
+ * divergent, weaker copy. This module is the single source of truth; engines
+ * call sanitizeSecrets(), and persistent-custom-session's buildSanitizer()
+ * extends SECRET_PATTERNS with user-configured RE2 patterns.
+ */
+
+export const SECRET_PATTERNS: ReadonlyArray<{ re: RegExp; replacement: string }> = [
+  // Authorization headers. The charset includes '.' so dotted tokens
+  // (e.g. Google OAuth ya29.* access tokens) are redacted whole.
+  { re: /Bearer [a-zA-Z0-9._-]+/g, replacement: 'Bearer ***' },
+  // OpenAI/Anthropic-style secret keys (sk-, sk-ant-, sk-proj-)
+  { re: /sk-[a-zA-Z0-9_-]{10,}/g, replacement: 'sk-***' },
+  // Generic `api_key: <value>` / `apiKey=<value>` assignments
+  { re: /(api[_-]?key["':= ]+)[a-zA-Z0-9._-]+/gi, replacement: '$1***' },
+  // SCREAMING_CASE secret env vars dumped to stderr
+  // (GEMINI_API_KEY=…, CURSOR_API_KEY=…, ANTHROPIC_API_KEY=…, *_TOKEN=…, *_SECRET=…)
+  { re: /\b([A-Z][A-Z0-9_]*(?:_KEY|_TOKEN|_SECRET))=\S+/g, replacement: '$1=***' },
+];
+
+/** Redact known secret shapes from a chunk of CLI output. */
+export function sanitizeSecrets(text: string): string {
+  let result = text;
+  for (const { re, replacement } of SECRET_PATTERNS) {
+    re.lastIndex = 0;
+    result = result.replace(re, replacement);
+  }
+  return result;
+}
+
+export interface SanitizerOptions {
+  extraPatterns?: string[];
+  label?: string;
+}
+
+/** Build a sanitizer from common secret patterns plus optional config patterns. */
+export function buildSanitizer(options: SanitizerOptions = {}): (text: string) => string {
+  const patterns: Array<{ re: RegExp; replacement: string }> = [...SECRET_PATTERNS];
+  for (const pattern of options.extraPatterns || []) {
+    try {
+      // RE2 runs in linear time and never backtracks, so user-supplied sanitize
+      // patterns cannot trigger ReDoS on attacker-influenced output.
+      patterns.push({ re: new RE2(pattern, 'g') as unknown as RegExp, replacement: '***' });
+    } catch (err) {
+      const label = options.label ? `[${options.label}] ` : '';
+      console.warn(`${label}ignoring invalid sanitizePattern ${JSON.stringify(pattern)}: ${(err as Error).message}`);
+    }
+  }
+
+  return (text: string): string => {
+    let result = text;
+    for (const { re, replacement } of patterns) {
+      re.lastIndex = 0;
+      result = result.replace(re, replacement);
+    }
+    return result;
+  };
+}

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -127,6 +127,7 @@ import { PersistentCodexSession } from './persistent-codex-session.js';
 import { PersistentCodexAppServerSession } from './persistent-codex-app-session.js';
 import { PersistentCursorSession } from './persistent-cursor-session.js';
 import { PersistentOpencodeSession } from './persistent-opencode-session.js';
+import { PersistentAgySession } from './persistent-agy-session.js';
 import { PersistentCustomSession } from './persistent-custom-session.js';
 import {
   type SessionConfig,
@@ -1711,6 +1712,7 @@ export class SessionManager {
       /(?:^|[/\s])claude(?:[\s/]|$)/, // claude CLI
       /(?:^|[/\s])codex(?:[\s/]|$)/, // codex CLI
       /(?:^|[/\s])gemini(?:[\s/]|$)/, // gemini CLI
+      /(?:^|[/\s])agy(?:[\s/]|$)/, // agy CLI (Google Antigravity)
       /(?:^|[/\s])cursor-agent(?:[\s/]|$)/, // cursor-agent CLI
       /(?:^|[/\s])opencode(?:[\s/]|$)/, // opencode CLI (sst/opencode)
       /(?:^|\/)agent(?:[\s/]|$)/, // 'agent' only as executable/after a slash (not ssh-agent)
@@ -1856,6 +1858,8 @@ export class SessionManager {
     switch (engine) {
       case 'gemini':
         return new PersistentGeminiSession(config, process.env.GEMINI_BIN);
+      case 'agy':
+        return new PersistentAgySession(config, process.env.AGY_BIN);
       case 'codex':
         return new PersistentCodexSession(config, process.env.CODEX_BIN);
       case 'codex-app':

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -152,6 +152,7 @@ import {
   overrideModelPricing,
 } from './types.js';
 import { resolveAlias, isClaudeModel } from './models.js';
+import { isAgyConversationId } from './agy-conversation.js';
 import { Council } from './council.js';
 import { Fanout, type FanoutConfig, type FanoutSession, type FanoutAgentSpec } from './fanout.js';
 import { AutoloopRunner } from './autoloop/runner.js';
@@ -186,6 +187,7 @@ interface ManagedSession {
   lastActivity: number;
   cwd: string;
   claudeSessionId?: string;
+  skipPersistence?: boolean;
   /**
    * Per-session send chain. Concurrent sendMessage() calls on the same session
    * MUST serialize, otherwise PersistentClaudeSession's single _streamCallbacks
@@ -513,6 +515,10 @@ export class SessionManager {
     // Starts a local proxy server that converts Anthropic → OpenAI format
     // and forwards to the OpenClaw gateway. Zero config required.
     const engine: EngineType = fullConfig.engine || persisted?.engine || 'claude';
+    // Write the resolved engine back so downstream consumers of the managed
+    // config (agy resume-id lookups, _persistSession's registry entry) see the
+    // real engine even when it came from the persisted registry.
+    fullConfig.engine = engine;
 
     // Circuit breaker — reject early if engine is in backoff
     this._circuitBreaker.check(engine);
@@ -551,7 +557,8 @@ export class SessionManager {
       created: persisted?.originalCreated || new Date().toISOString(),
       lastActivity: Date.now(),
       cwd: fullConfig.cwd,
-      claudeSessionId: session.sessionId,
+      claudeSessionId: this._sessionResumeId(engine, session),
+      skipPersistence: skipPersist,
     };
 
     this.sessions.set(name, managed);
@@ -633,11 +640,12 @@ export class SessionManager {
 
       const result = await managed.session.send(message, sendOpts);
 
-      // Update session ID if available (skip disk persist for ephemeral
-      // sessions that were started with skipPersistence)
-      if (managed.session.sessionId) {
-        managed.claudeSessionId = managed.session.sessionId;
-        if (this.persistedSessions.has(name)) {
+      // Update the resume-capable session ID if available (skip disk persist
+      // for ephemeral sessions that were started with skipPersistence)
+      const resumableId = this._managedResumeId(managed);
+      if (resumableId) {
+        managed.claudeSessionId = resumableId;
+        if (!managed.skipPersistence) {
           this._persistSession(name, managed);
         }
       }
@@ -645,12 +653,12 @@ export class SessionManager {
       if ('text' in result) {
         return {
           output: result.text,
-          sessionId: managed.claudeSessionId,
+          sessionId: this._managedResumeId(managed),
           events: [],
         };
       }
 
-      return { output: '', sessionId: managed.claudeSessionId, events: [] };
+      return { output: '', sessionId: this._managedResumeId(managed), events: [] };
     } finally {
       releaseChain();
       // If this was the tail of the chain, clear it so memory doesn't grow.
@@ -753,8 +761,12 @@ export class SessionManager {
       );
     }
 
-    const sessionId = managed.claudeSessionId || managed.session.sessionId;
-    if (!sessionId) throw new Error(`Session '${name}' has no claude session ID — cannot resume after restart`);
+    // An agy session with no harvested conversation yet has no history to
+    // preserve — restart it fresh instead of rejecting the switch.
+    const sessionId = this._managedResumeId(managed);
+    if (!sessionId && managed.config.engine !== 'agy') {
+      throw new Error(`Session '${name}' has no claude session ID — cannot resume after restart`);
+    }
 
     // Validate model — must be a known alias or contain a recognisable pattern
     const resolvedModel = this._resolveModel(model, managed.config.modelOverrides);
@@ -775,13 +787,13 @@ export class SessionManager {
         ...oldConfig,
         name,
         model,
-        resumeSessionId: sessionId,
+        ...(sessionId ? { resumeSessionId: sessionId } : {}),
       });
     } catch (err) {
       // Rollback: restart with original config
       this.logger.error(`switchModel failed for '${name}', attempting rollback:`, err);
       try {
-        await this.startSession({ ...oldConfig, name, resumeSessionId: sessionId });
+        await this.startSession({ ...oldConfig, name, ...(sessionId ? { resumeSessionId: sessionId } : {}) });
       } catch (rollbackErr) {
         this.logger.error(`Rollback also failed for '${name}':`, rollbackErr);
       }
@@ -819,8 +831,12 @@ export class SessionManager {
       );
     }
 
-    const sessionId = managed.claudeSessionId || managed.session.sessionId;
-    if (!sessionId) throw new Error(`Session '${name}' has no claude session ID — cannot resume after restart`);
+    // An agy session with no harvested conversation yet has no history to
+    // preserve — restart it fresh instead of rejecting the update.
+    const sessionId = this._managedResumeId(managed);
+    if (!sessionId && managed.config.engine !== 'agy') {
+      throw new Error(`Session '${name}' has no claude session ID — cannot resume after restart`);
+    }
 
     const oldConfig = { ...managed.config };
     let newAllowed = opts.allowedTools;
@@ -851,12 +867,12 @@ export class SessionManager {
         name,
         allowedTools: newAllowed,
         disallowedTools: newDisallowed,
-        resumeSessionId: sessionId,
+        ...(sessionId ? { resumeSessionId: sessionId } : {}),
       });
     } catch (err) {
       this.logger.error(`updateTools failed for '${name}', attempting rollback:`, err);
       try {
-        await this.startSession({ ...oldConfig, name, resumeSessionId: sessionId });
+        await this.startSession({ ...oldConfig, name, ...(sessionId ? { resumeSessionId: sessionId } : {}) });
       } catch (rollbackErr) {
         this.logger.error(`Rollback also failed for '${name}':`, rollbackErr);
       }
@@ -1013,7 +1029,7 @@ export class SessionManager {
       output: deliveryResult.delivered
         ? `Message delivered to ${teammate}`
         : `Message queued for ${teammate} (session is busy)`,
-      sessionId: managed.claudeSessionId,
+      sessionId: this._managedResumeId(managed),
       events: [],
     };
   }
@@ -1629,11 +1645,18 @@ export class SessionManager {
   // ─── Private ───────────────────────────────────────────────────────────
 
   private _persistSession(name: string, managed: ManagedSession): void {
-    if (!managed.claudeSessionId) return;
+    const resumeSessionId = this._managedResumeId(managed);
+    if (!resumeSessionId) {
+      if (managed.config.engine === 'agy' && this.persistedSessions.delete(name)) {
+        this._debouncedSave();
+      }
+      return;
+    }
+    managed.claudeSessionId = resumeSessionId;
     const existing = this.persistedSessions.get(name);
     this.persistedSessions.set(name, {
       name,
-      claudeSessionId: managed.claudeSessionId,
+      claudeSessionId: resumeSessionId,
       cwd: managed.cwd,
       model: managed.config.resolvedModel || managed.config.model,
       engine: managed.config.engine,
@@ -1826,9 +1849,11 @@ export class SessionManager {
 
   private _toSessionInfo(name: string, managed: ManagedSession): SessionInfo {
     const stats = managed.session.getStats();
+    const resumeSessionId = this._managedResumeId(managed);
+    if (resumeSessionId) managed.claudeSessionId = resumeSessionId;
     return {
       name,
-      claudeSessionId: managed.claudeSessionId,
+      claudeSessionId: resumeSessionId,
       created: managed.created,
       cwd: managed.cwd,
       model: managed.config.resolvedModel || managed.config.model,
@@ -1840,6 +1865,31 @@ export class SessionManager {
   private _resolveModel(alias: string, overrides?: Record<string, string>): string {
     if (overrides?.[alias]) return overrides[alias];
     return resolveAlias(alias);
+  }
+
+  private _managedResumeId(managed: ManagedSession): string | undefined {
+    return (
+      this._sessionResumeId(managed.config.engine, managed.session) ||
+      this._storedResumeId(managed.config.engine, managed.claudeSessionId)
+    );
+  }
+
+  /**
+   * Return only IDs that can actually resume the engine. For agy,
+   * session.sessionId is synthetic (`agy-<ts>-<rand>`); only the harvested
+   * conversation UUID works with `--conversation`.
+   */
+  private _sessionResumeId(engine: EngineType | undefined, session: ISession): string | undefined {
+    if (engine === 'agy') {
+      const conversationId = (session as { conversationId?: string }).conversationId;
+      return isAgyConversationId(conversationId) ? conversationId : undefined;
+    }
+    return session.sessionId;
+  }
+
+  private _storedResumeId(engine: EngineType | undefined, id: string | undefined): string | undefined {
+    if (engine === 'agy') return isAgyConversationId(id) ? id : undefined;
+    return id;
   }
 
   private _listMdFiles(dir: string): AgentInfo[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'auto';
 
 // ─── Engine ─────────────────────────────────────────────────────────────────
 
-export type EngineType = 'claude' | 'codex' | 'codex-app' | 'gemini' | 'cursor' | 'opencode' | 'custom';
+export type EngineType = 'claude' | 'codex' | 'codex-app' | 'gemini' | 'agy' | 'cursor' | 'opencode' | 'custom';
 
 // ─── Custom Engine Config ───────────────────────────────────────────────────
 //
@@ -296,6 +296,8 @@ export interface SessionStats {
   pluginErrors?: Array<{ plugin: string; reason: string }>;
   /** Codex thread ID captured from the most recent `thread.started` event (Codex 0.119+). Used by `codex_resume`. */
   codexThreadId?: string;
+  /** Antigravity conversation ID harvested from the agy log file after the first turn. Reused via `--conversation` for multi-turn context. */
+  agyConversationId?: string;
 }
 
 // ─── Hook Config ─────────────────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,8 @@ export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'auto';
 
 // ─── Engine ─────────────────────────────────────────────────────────────────
 
-export type EngineType = 'claude' | 'codex' | 'codex-app' | 'gemini' | 'agy' | 'cursor' | 'opencode' | 'custom';
+export const ENGINE_TYPES = ['claude', 'codex', 'codex-app', 'gemini', 'agy', 'cursor', 'opencode', 'custom'] as const;
+export type EngineType = (typeof ENGINE_TYPES)[number];
 
 // ─── Custom Engine Config ───────────────────────────────────────────────────
 //


### PR DESCRIPTION
## What

Adds `engine: 'agy'` — a built-in engine for **Google Antigravity CLI**, the successor to Gemini CLI (consumer Gemini CLI tiers stopped serving 2026-06-18). This graduates the custom-engine recipe in `multi-engine.md` (which targets agy 1.0.2) to first-class support, verified against **agy 1.0.16**.

## Why a real engine instead of the recipe

The recipe's two documented caveats are exactly what a built-in engine can fix:

1. **Conversation continuity.** agy logs `Created conversation <uuid>` to its log file. The engine passes a private `--log-file` per session, harvests the ID after the first turn, and resumes with `--conversation <id>` on subsequent sends — the same multi-turn semantics as Codex thread resume. Seedable via `resumeSessionId`; exposed as `stats.agyConversationId` (mirrors `codexThreadId`).
2. **Timeout coherence.** agy enforces its own `--print-timeout` (default 5m). The engine derives it from the send timeout (+5s margin) so the wrapper timer decides the outcome, never agy's internal default.

Plus: permission-mode mapping (`bypassPermissions` → `--dangerously-skip-permissions`, `default` → `--sandbox`), stderr secret redaction, per-session log cleanup on `stop()`, `AGY_BIN` binary override, and the `agy` binary added to the known-CLI kill guard.

## Limitations (documented in multi-engine.md)

- agy 1.0.16 still has **no structured output mode** — stdout is plain text, so tool-call events aren't visible and **token counts are estimated** (~4 chars/token), same as the recipe.
- Unknown `--model` slugs **silently fall back** to agy's default model (verified empirically) — noted in the model-registry comment.

## Registry

- `gemini-3.5-flash` (alias `agy-flash`) and `gemini-3.1-pro` (alias `agy-pro`) under the new engine; slugs verified against `agy models` on 1.0.16. agy-proxied Claude/GPT-OSS models pass through unregistered.
- `agy/` added to the vendor-prefix strip lists.

## Testing

- **15 new unit tests** (`src/__tests__/agy-session.test.ts`): flag construction, print-timeout derivation, conversation harvest/seed/keep-on-miss, plain-text accumulation + trailing-newline trim, token estimation, exit-code rejection, stop/log-cleanup, compact no-op, default pricing, stderr redaction.
- **Full suite: 823/823 green**; `npm run build` + `npm run lint` clean.
- **Live verification** against real agy 1.0.16: two-turn codeword-recall test through the built engine — turn 1 stores, turn 2 recalls via the harvested `--conversation` ID; conversation ID surfaced in stats.

Docs updated: `multi-engine.md` (new engine section + recipe marked as legacy fallback), README engine table, SKILL.md engine tables/description, CLAUDE.md file map + compatibility table, CHANGELOG (Unreleased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)