### PR TITLE
fix: register MiniMax-M3 and MiniMax-M2.7 in the model registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Registered MiniMax-M3 and MiniMax-M2.7 in the model registry.** The proxy
+  already forwards these through its configurable Anthropic-compatible base URL,
+  but the models were absent from `src/models.ts`, so they fell through the
+  provider pattern fallback and inherited the default 200K context window and
+  fallback pricing. They now carry their real windows (1,000,000 and 204,800
+  tokens) and pricing ($0.6/$2.4 and $0.3/$1.2 per Mtok, cache read $0.12 and
+  $0.06) and resolve to the `anthropic` provider.
+
 ## [4.10.1] - 2026-08-01
 
 Weekly engine sweep. Two `sandboxMode: 'read-only'` guarantees did not hold and

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -303,6 +303,46 @@ describe('gpt-5.5', () => {
   });
 });
 
+// Regression guard: these are served through the proxy's configurable
+// Anthropic-compatible base URL, so they must resolve to the `anthropic`
+// provider (not the pattern fallback) and carry their real windows and pricing
+// rather than the default 200K window / fallback pricing.
+describe('MiniMax-M3', () => {
+  it('is registered with a 1M context and MiniMax pricing on the anthropic provider', () => {
+    const m = lookupModel('MiniMax-M3');
+    expect(m).toBeDefined();
+    expect(m!.provider).toBe('anthropic');
+    expect(m!.contextWindow).toBe(1_000_000);
+    expect(m!.pricing.input).toBe(0.6);
+    expect(m!.pricing.output).toBe(2.4);
+    expect(m!.pricing.cached).toBe(0.12);
+  });
+
+  it('routes to the anthropic provider with correct window and pricing', () => {
+    expect(resolveProvider('MiniMax-M3')).toEqual({ provider: 'anthropic', apiModel: 'MiniMax-M3' });
+    expect(getContextWindow('MiniMax-M3')).toBe(1_000_000);
+    expect(getModelPricing('MiniMax-M3').input).toBe(0.6);
+  });
+});
+
+describe('MiniMax-M2.7', () => {
+  it('is registered with a 204,800 context and MiniMax pricing on the anthropic provider', () => {
+    const m = lookupModel('MiniMax-M2.7');
+    expect(m).toBeDefined();
+    expect(m!.provider).toBe('anthropic');
+    expect(m!.contextWindow).toBe(204_800);
+    expect(m!.pricing.input).toBe(0.3);
+    expect(m!.pricing.output).toBe(1.2);
+    expect(m!.pricing.cached).toBe(0.06);
+  });
+
+  it('routes to the anthropic provider with correct window and pricing', () => {
+    expect(resolveProvider('MiniMax-M2.7')).toEqual({ provider: 'anthropic', apiModel: 'MiniMax-M2.7' });
+    expect(getContextWindow('MiniMax-M2.7')).toBe(204_800);
+    expect(getModelPricing('MiniMax-M2.7').input).toBe(0.3);
+  });
+});
+
 describe('isGeminiModel / isClaudeModel', () => {
   it('detects gemini models', () => {
     expect(isGeminiModel('gemini-3-flash-preview')).toBe(true);

--- a/src/models.ts
+++ b/src/models.ts
@@ -294,6 +294,30 @@ const MODELS: ModelDef[] = [
     contextWindow: 200_000,
   },
 
+  // ── MiniMax (Anthropic-compatible endpoint) ────────────────────────────
+  // Served through the proxy's configurable Anthropic base URL
+  // (getAnthropicBaseUrl → ANTHROPIC_BASE_URL / OpenClaw config), so these run
+  // on the claude engine and route to the `anthropic` provider. Without an
+  // entry here they fell through resolveProvider's pattern fallback to a
+  // provider that never uses that base URL, and inherited the default 200K
+  // context window and fallback pricing instead of their real values.
+  // MiniMax-M3: 1M-token window; $0.6/$2.4 per Mtok, cache read $0.12.
+  {
+    id: 'MiniMax-M3',
+    engine: 'claude',
+    provider: 'anthropic',
+    pricing: { input: 0.6, output: 2.4, cached: 0.12 },
+    contextWindow: 1_000_000,
+  },
+  // MiniMax-M2.7: 204,800-token window; $0.3/$1.2 per Mtok, cache read $0.06.
+  {
+    id: 'MiniMax-M2.7',
+    engine: 'claude',
+    provider: 'anthropic',
+    pricing: { input: 0.3, output: 1.2, cached: 0.06 },
+    contextWindow: 204_800,
+  },
+
   // ── Legacy (backward compat) ───────────────────────────────────────────
   {
     id: 'gpt-4o',


### PR DESCRIPTION
Reason: MiniMax-M3 and MiniMax-M2.7 were missing from the model registry, so they inherited the default context window and fallback pricing instead of routing correctly.

The proxy already forwards requests through its configurable Anthropic-compatible base URL (`getAnthropicBaseUrl`), but `MiniMax-M3` and `MiniMax-M2.7` had no entry in `src/models.ts`. They therefore fell through `resolveProvider`'s pattern fallback to a provider that never uses that base URL, and `getContextWindow` / `getModelPricing` returned the default 200K window and fallback pricing.

## Changes

- Register `MiniMax-M3` (1,000,000-token window; $0.6/$2.4 per Mtok, cache read $0.12) and `MiniMax-M2.7` (204,800-token window; $0.3/$1.2 per Mtok, cache read $0.06) in the central registry, both on the `claude` engine and the `anthropic` provider so they route through the configurable Anthropic-compatible base URL.
- Add regression tests asserting each model's provider, context window, and pricing, and that `resolveProvider` / `getContextWindow` / `getModelPricing` resolve them correctly.
- Add a CHANGELOG entry.

## Checks

- `npx tsc --noEmit` — passes
- `npx eslint src/models.ts src/__tests__/models.test.ts` — passes
- `npx prettier --check src/models.ts src/__tests__/models.test.ts` — passes
- `npx vitest run src/__tests__/models.test.ts` — 46 passed
