### PR TITLE
fix(openai-compat): require a live conversation id before sending the tool reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The resume-turn tool reminder was gated on the session existing in the manager's
+  map, which is not the same as the engine having created a conversation.
+  `start()` does not spawn a process, the conversation id is only captured later
+  (`codex` on `thread.started`, `agy` by harvesting the log after the first turn),
+  and a send that fails before that point leaves the session in the map with no id.
+  The next turn then sent a reminder referring to tools the engine had never
+  received — no schemas, no identity, no history — and still answered 200. The gate
+  now also requires the id to be present, so a conversation that was never created
+  falls back to the full block. Behaviour is unchanged once a thread is live.
+
 ## [4.11.0] - 2026-08-04
 
 ### Fixed

--- a/skills/references/openai-compat.md
+++ b/skills/references/openai-compat.md
@@ -81,7 +81,7 @@ mechanism is used depends on whether the engine keeps the conversation itself.
 | Engine | Turn 1 | Later turns |
 |---|---|---|
 | `claude` | Schemas go into the session system prompt (`--system-prompt`) | Nothing injected — the system prompt persists |
-| `codex`, `codex-app`, `agy` | Full schema block prepended to the message | A short reminder of the calling convention, no schemas |
+| `codex`, `codex-app`, `agy` | Full schema block prepended to the message | A short reminder of the calling convention, no schemas — but only once the conversation id has been captured; until then the full block is sent again |
 | `cursor`, `opencode`, `gemini` | Full schema block prepended to the message | Full schema block again — these spawn a fresh process per send and remember nothing |
 
 The middle row is the one worth understanding. Those engines resume a thread, so

--- a/src/__tests__/openai-compat.test.ts
+++ b/src/__tests__/openai-compat.test.ts
@@ -11,6 +11,7 @@ import {
   formatCompletionChunk,
   buildToolPromptBlock,
   buildToolReminderBlock,
+  nativeThreadIsLive,
   parseToolCallsFromText,
   serializeToolResults,
   isToolsPerMessageModeEnabled,
@@ -798,5 +799,39 @@ describe('formatCompletionResponse with tool_calls', () => {
     expect(resp.choices[0].finish_reason).toBe('tool_calls');
     expect(resp.choices[0].message.content).toBe('Thinking...');
     expect(resp.choices[0].message.tool_calls).toEqual(toolCalls);
+  });
+});
+
+describe('nativeThreadIsLive', () => {
+  // The regression this guards: `!needsCreate` says the session is in the manager's map, which is
+  // not the same as the engine having created a conversation. A first send that dies before
+  // `thread.started` leaves the session in the map with no id, and the next turn would then send a
+  // reminder referring to tools the engine never received — and still answer 200.
+  it('requires a captured thread id for codex', () => {
+    expect(nativeThreadIsLive('codex', {})).toBe(false);
+    expect(nativeThreadIsLive('codex', { codexThreadId: 'thread_abc' })).toBe(true);
+  });
+
+  it('requires a captured thread id for codex-app', () => {
+    expect(nativeThreadIsLive('codex-app', {})).toBe(false);
+    expect(nativeThreadIsLive('codex-app', { codexThreadId: 'thread_abc' })).toBe(true);
+  });
+
+  it('requires a harvested conversation id for agy', () => {
+    expect(nativeThreadIsLive('agy', {})).toBe(false);
+    expect(nativeThreadIsLive('agy', { agyConversationId: 'conv_abc' })).toBe(true);
+  });
+
+  it('does not confuse the two ids', () => {
+    expect(nativeThreadIsLive('codex', { agyConversationId: 'conv_abc' })).toBe(false);
+    expect(nativeThreadIsLive('agy', { codexThreadId: 'thread_abc' })).toBe(false);
+  });
+
+  it('treats engines that keep context in a live process as live', () => {
+    // claude and persistent custom engines expose no separate id, so presence in the map is the
+    // strongest signal there is; this must not regress to false.
+    expect(nativeThreadIsLive('claude', {})).toBe(true);
+    expect(nativeThreadIsLive('custom', {})).toBe(true);
+    expect(nativeThreadIsLive(undefined, {})).toBe(true);
   });
 });

--- a/src/openai-compat.ts
+++ b/src/openai-compat.ts
@@ -12,7 +12,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { randomUUID, createHash } from 'node:crypto';
 import { resolveEngineAndModel, estimateTokens } from './models.js';
-import { engineHasNativeConversation } from './types.js';
+import { engineHasNativeConversation, type EngineType, type SessionStats } from './types.js';
 import {
   OPENAI_COMPAT_DEFAULT_MODEL,
   OPENAI_COMPAT_AUTO_COMPACT_THRESHOLD,
@@ -523,8 +523,47 @@ interface SessionManagerLike {
   ): Promise<{ output: string; sessionId?: string; events: unknown[] }>;
   stopSession(name: string): Promise<void>;
   listSessions(): Array<{ name: string }>;
-  getStatus(name: string): { stats: { tokensIn: number; tokensOut: number; contextPercent: number } };
+  getStatus(name: string): {
+    stats: {
+      tokensIn: number;
+      tokensOut: number;
+      contextPercent: number;
+      // Native-conversation ids. Optional because they only exist once the engine has actually
+      // announced the conversation — see nativeThreadIsLive().
+      codexThreadId?: string;
+      agyConversationId?: string;
+    };
+  };
   compactSession(name: string): Promise<unknown>;
+}
+
+/**
+ * Whether the engine's native conversation is known to exist for this session.
+ *
+ * `!needsCreate` only says the session is in the manager's map, which is not the same thing:
+ * `start()` does not spawn a process, the conversation id is captured later (codex sets it on
+ * `thread.started`, agy harvests it from the log after the first turn), and a send that fails
+ * before that point leaves the session in the map with no id at all.
+ *
+ * The distinction matters wherever we decide to send a short reminder instead of the full state,
+ * because a reminder that refers to a conversation the engine never created is silently wrong —
+ * the request still returns 200.
+ */
+export function nativeThreadIsLive(
+  engine: EngineType | undefined,
+  stats: Pick<SessionStats, 'codexThreadId' | 'agyConversationId'>,
+): boolean {
+  switch (engine) {
+    case 'codex':
+    case 'codex-app':
+      return !!stats.codexThreadId;
+    case 'agy':
+      return !!stats.agyConversationId;
+    default:
+      // claude and persistent custom engines hold their context in a live process, so there is no
+      // separate id to check — being in the map is the strongest signal available.
+      return true;
+  }
 }
 
 export async function handleChatCompletion(
@@ -707,7 +746,15 @@ export async function handleChatCompletion(
   const perMessageMode = isToolsPerMessageModeEnabled();
   const injectToolsPerTurn = hasTools && (engine !== 'claude' || perMessageMode);
   if (injectToolsPerTurn) {
-    const schemasAlreadyInThread = !needsCreate && !perMessageMode && engineHasNativeConversation(engine);
+    let schemasAlreadyInThread = false;
+    if (!needsCreate && !perMessageMode && engineHasNativeConversation(engine)) {
+      try {
+        schemasAlreadyInThread = nativeThreadIsLive(engine, manager.getStatus(sessionName).stats);
+      } catch {
+        // getStatus throws once the session is gone from the map; that is not a live thread.
+        schemasAlreadyInThread = false;
+      }
+    }
     const toolBlock = schemasAlreadyInThread ? buildToolReminderBlock() : buildToolPromptBlock(request.tools);
     userMessage = `${toolBlock}\n\n${userMessage}`;
   }


### PR DESCRIPTION
## The problem

`schemasAlreadyInThread` gates the resume-turn reminder on `!needsCreate`, which only says the session is present in the manager's map. That is weaker than it looks:

- `start()` ([`base-oneshot-session.ts:103`](../blob/main/src/base-oneshot-session.ts#L103)) resolves the cwd, assigns a session id, sets `_isReady` and emits `ready`. It does not spawn anything.
- The conversation id is captured later — `codex` on `thread.started` ([`persistent-codex-session.ts:220`](../blob/main/src/persistent-codex-session.ts#L220)), `agy` by harvesting the log after the first turn.
- A send that fails before that point does not remove the session from the map.

So after a failed first send, the next turn sees `sessionExists = true`, takes the resumed-thread path, and sends `buildToolReminderBlock()` — a reminder about tools the engine has never received. No schemas, no identity, no history. The request returns **200** with whatever the model makes of it.

It is a quiet failure: nothing in the logs distinguishes it from a healthy resume, which is why it took a while to find in our deployment.

## The change

Require the id to actually be there:

```ts
if (!needsCreate && !perMessageMode && engineHasNativeConversation(engine)) {
  try {
    schemasAlreadyInThread = nativeThreadIsLive(engine, manager.getStatus(sessionName).stats);
  } catch {
    schemasAlreadyInThread = false;
  }
}
```

`nativeThreadIsLive()` is exported as a small pure predicate so the rule can be tested directly rather than through `handleChatCompletion`, which has no coverage today.

Both failure directions are safe by construction: when in doubt it sends the **full** block, which is correct but larger, never the reminder-without-schemas.

`SessionManagerLike.getStatus` declared its return shape by hand and left both ids out; they are added as optional, which is what they are on `SessionStats`.

## Behaviour

| situation | before | after |
|---|---|---|
| thread live (the normal case) | reminder | reminder — unchanged |
| session in map, id never captured | reminder about tools the engine never saw | full block |
| `perMessageMode`, fresh session, one-shot engines | full block | full block — unchanged |

## Tests

Six cases on the predicate: id required for `codex` / `codex-app` / `agy`, the two ids not interchangeable, and engines that hold context in a live process still treated as live so `claude` does not regress.

`npm run build`, `npm run lint`, `npm run format:check` clean; `vitest run` green at **900/900** across 58 files.

## Why this one first

We run this in production on the `codex` engine (~15 agents) and have two more changes queued that both need a trustworthy "is the thread really there" predicate — trimming already-sent tool results, and skipping the system prompt on resumed turns. Both are unsafe on top of `!needsCreate` alone, so this seemed like the right thing to send first and on its own.

Separately filed #75, on `contextPercent` and the auto-compaction gate — not bundled here since it is a different area.
