### PR TITLE
fix(openai-compat): stop re-sending tool results the thread already holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Tool results were re-serialized in full on every hop of a tool loop. On engines
+  that resume a conversation the earlier results are already in the transcript, so
+  each hop re-sent the whole history and the prompt grew quadratically: with a 30k
+  character batch per round, hop 10 carried ~300k characters the engine had already
+  seen. Results are now scoped to the round that answers the engine's latest
+  assistant turn whenever the conversation is known to hold the rest — same
+  predicate as the tool reminder. Sessions whose thread cannot be confirmed keep
+  sending everything.
+
 - The resume-turn tool reminder was gated on the session existing in the manager's
   map, which is not the same as the engine having created a conversation.
   `start()` does not spawn a process, the conversation id is only captured later

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The resume-turn tool reminder was gated on the session existing in the manager's
+  map, which is not the same as the engine having created a conversation.
+  `start()` does not spawn a process, the conversation id is only captured later
+  (`codex` on `thread.started`, `agy` by harvesting the log after the first turn),
+  and a send that fails before that point leaves the session in the map with no id.
+  The next turn then sent a reminder referring to tools the engine had never
+  received — no schemas, no identity, no history — and still answered 200. The gate
+  now also requires the id to be present, so a conversation that was never created
+  falls back to the full block. Behaviour is unchanged once a thread is live.
+
 ## [4.11.0] - 2026-08-04
 
 ### Fixed

--- a/skills/references/openai-compat.md
+++ b/skills/references/openai-compat.md
@@ -81,7 +81,7 @@ mechanism is used depends on whether the engine keeps the conversation itself.
 | Engine | Turn 1 | Later turns |
 |---|---|---|
 | `claude` | Schemas go into the session system prompt (`--system-prompt`) | Nothing injected — the system prompt persists |
-| `codex`, `codex-app`, `agy` | Full schema block prepended to the message | A short reminder of the calling convention, no schemas |
+| `codex`, `codex-app`, `agy` | Full schema block prepended to the message | A short reminder of the calling convention, no schemas — but only once the conversation id has been captured; until then the full block is sent again |
 | `cursor`, `opencode`, `gemini` | Full schema block prepended to the message | Full schema block again — these spawn a fresh process per send and remember nothing |
 
 The middle row is the one worth understanding. Those engines resume a thread, so

--- a/src/__tests__/openai-compat.test.ts
+++ b/src/__tests__/openai-compat.test.ts
@@ -11,6 +11,7 @@ import {
   formatCompletionChunk,
   buildToolPromptBlock,
   buildToolReminderBlock,
+  nativeThreadIsLive,
   parseToolCallsFromText,
   serializeToolResults,
   isToolsPerMessageModeEnabled,
@@ -798,5 +799,39 @@ describe('formatCompletionResponse with tool_calls', () => {
     expect(resp.choices[0].finish_reason).toBe('tool_calls');
     expect(resp.choices[0].message.content).toBe('Thinking...');
     expect(resp.choices[0].message.tool_calls).toEqual(toolCalls);
+  });
+});
+
+describe('nativeThreadIsLive', () => {
+  // The regression this guards: `!needsCreate` says the session is in the manager's map, which is
+  // not the same as the engine having created a conversation. A first send that dies before
+  // `thread.started` leaves the session in the map with no id, and the next turn would then send a
+  // reminder referring to tools the engine never received — and still answer 200.
+  it('requires a captured thread id for codex', () => {
+    expect(nativeThreadIsLive('codex', {})).toBe(false);
+    expect(nativeThreadIsLive('codex', { codexThreadId: 'thread_abc' })).toBe(true);
+  });
+
+  it('requires a captured thread id for codex-app', () => {
+    expect(nativeThreadIsLive('codex-app', {})).toBe(false);
+    expect(nativeThreadIsLive('codex-app', { codexThreadId: 'thread_abc' })).toBe(true);
+  });
+
+  it('requires a harvested conversation id for agy', () => {
+    expect(nativeThreadIsLive('agy', {})).toBe(false);
+    expect(nativeThreadIsLive('agy', { agyConversationId: 'conv_abc' })).toBe(true);
+  });
+
+  it('does not confuse the two ids', () => {
+    expect(nativeThreadIsLive('codex', { agyConversationId: 'conv_abc' })).toBe(false);
+    expect(nativeThreadIsLive('agy', { codexThreadId: 'thread_abc' })).toBe(false);
+  });
+
+  it('treats engines that keep context in a live process as live', () => {
+    // claude and persistent custom engines expose no separate id, so presence in the map is the
+    // strongest signal there is; this must not regress to false.
+    expect(nativeThreadIsLive('claude', {})).toBe(true);
+    expect(nativeThreadIsLive('custom', {})).toBe(true);
+    expect(nativeThreadIsLive(undefined, {})).toBe(true);
   });
 });

--- a/src/__tests__/openai-compat.test.ts
+++ b/src/__tests__/openai-compat.test.ts
@@ -14,6 +14,7 @@ import {
   nativeThreadIsLive,
   parseToolCallsFromText,
   serializeToolResults,
+  type OpenAIChatMessage,
   isToolsPerMessageModeEnabled,
   noToolsSystemPrompt,
   buildSessionSystemPrompt,
@@ -833,5 +834,56 @@ describe('nativeThreadIsLive', () => {
     expect(nativeThreadIsLive('claude', {})).toBe(true);
     expect(nativeThreadIsLive('custom', {})).toBe(true);
     expect(nativeThreadIsLive(undefined, {})).toBe(true);
+  });
+});
+
+describe('serializeToolResults — latestRoundOnly', () => {
+  // Growth is the point: on a resumed thread every result before the engine's last assistant turn
+  // is already in the transcript, so re-sending them makes the prompt grow quadratically across a
+  // tool loop. Scoping to the latest round keeps it linear.
+  const loop: OpenAIChatMessage[] = [
+    { role: 'user', content: 'go' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{ id: 'c1', type: 'function', function: { name: 'a', arguments: '{}' } }],
+    },
+    { role: 'tool', tool_call_id: 'c1', content: 'RESULT-ONE' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{ id: 'c2', type: 'function', function: { name: 'b', arguments: '{}' } }],
+    },
+    { role: 'tool', tool_call_id: 'c2', content: 'RESULT-TWO' },
+  ];
+
+  it('sends every result when the thread cannot be trusted to hold them', () => {
+    const out = serializeToolResults(loop, false);
+    expect(out).toContain('RESULT-ONE');
+    expect(out).toContain('RESULT-TWO');
+  });
+
+  it('sends only the results answering the latest round when the thread holds the rest', () => {
+    const out = serializeToolResults(loop, true);
+    expect(out).not.toContain('RESULT-ONE');
+    expect(out).toContain('RESULT-TWO');
+  });
+
+  it('defaults to the previous behaviour', () => {
+    expect(serializeToolResults(loop)).toContain('RESULT-ONE');
+  });
+
+  it('keeps every result when no assistant turn has happened yet', () => {
+    // First hop of a resumed session: results with no preceding assistant message are all new.
+    const noAssistant: OpenAIChatMessage[] = [
+      { role: 'user', content: 'go' },
+      { role: 'tool', tool_call_id: 'c1', content: 'RESULT-ONE' },
+    ];
+    expect(serializeToolResults(noAssistant, true)).toContain('RESULT-ONE');
+  });
+
+  it('returns empty when the latest round produced no results', () => {
+    const trailingAssistant: OpenAIChatMessage[] = [...loop, { role: 'assistant', content: 'done' }];
+    expect(serializeToolResults(trailingAssistant, true)).toBe('');
   });
 });

--- a/src/openai-compat.ts
+++ b/src/openai-compat.ts
@@ -12,7 +12,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { randomUUID, createHash } from 'node:crypto';
 import { resolveEngineAndModel, estimateTokens } from './models.js';
-import { engineHasNativeConversation } from './types.js';
+import { engineHasNativeConversation, type EngineType, type SessionStats } from './types.js';
 import {
   OPENAI_COMPAT_DEFAULT_MODEL,
   OPENAI_COMPAT_AUTO_COMPACT_THRESHOLD,
@@ -523,8 +523,47 @@ interface SessionManagerLike {
   ): Promise<{ output: string; sessionId?: string; events: unknown[] }>;
   stopSession(name: string): Promise<void>;
   listSessions(): Array<{ name: string }>;
-  getStatus(name: string): { stats: { tokensIn: number; tokensOut: number; contextPercent: number } };
+  getStatus(name: string): {
+    stats: {
+      tokensIn: number;
+      tokensOut: number;
+      contextPercent: number;
+      // Native-conversation ids. Optional because they only exist once the engine has actually
+      // announced the conversation — see nativeThreadIsLive().
+      codexThreadId?: string;
+      agyConversationId?: string;
+    };
+  };
   compactSession(name: string): Promise<unknown>;
+}
+
+/**
+ * Whether the engine's native conversation is known to exist for this session.
+ *
+ * `!needsCreate` only says the session is in the manager's map, which is not the same thing:
+ * `start()` does not spawn a process, the conversation id is captured later (codex sets it on
+ * `thread.started`, agy harvests it from the log after the first turn), and a send that fails
+ * before that point leaves the session in the map with no id at all.
+ *
+ * The distinction matters wherever we decide to send a short reminder instead of the full state,
+ * because a reminder that refers to a conversation the engine never created is silently wrong —
+ * the request still returns 200.
+ */
+export function nativeThreadIsLive(
+  engine: EngineType | undefined,
+  stats: Pick<SessionStats, 'codexThreadId' | 'agyConversationId'>,
+): boolean {
+  switch (engine) {
+    case 'codex':
+    case 'codex-app':
+      return !!stats.codexThreadId;
+    case 'agy':
+      return !!stats.agyConversationId;
+    default:
+      // claude and persistent custom engines hold their context in a live process, so there is no
+      // separate id to check — being in the map is the strongest signal available.
+      return true;
+  }
 }
 
 export async function handleChatCompletion(
@@ -707,7 +746,15 @@ export async function handleChatCompletion(
   const perMessageMode = isToolsPerMessageModeEnabled();
   const injectToolsPerTurn = hasTools && (engine !== 'claude' || perMessageMode);
   if (injectToolsPerTurn) {
-    const schemasAlreadyInThread = !needsCreate && !perMessageMode && engineHasNativeConversation(engine);
+    let schemasAlreadyInThread = false;
+    if (!needsCreate && !perMessageMode && engineHasNativeConversation(engine)) {
+      try {
+        schemasAlreadyInThread = nativeThreadIsLive(engine, manager.getStatus(sessionName).stats);
+      } catch {
+        // getStatus throws once the session is gone from the map; that is not a live thread.
+        schemasAlreadyInThread = false;
+      }
+    }
     const toolBlock = schemasAlreadyInThread ? buildToolReminderBlock() : buildToolPromptBlock(request.tools);
     userMessage = `${toolBlock}\n\n${userMessage}`;
   }

--- a/src/openai-compat.ts
+++ b/src/openai-compat.ts
@@ -353,8 +353,14 @@ export function parseToolCallsFromText(text: string): ParsedToolCalls {
  * Serialize tool result messages into a text block for the CLI model.
  * Converts OpenAI `tool` role messages into <tool_result> tags.
  */
-export function serializeToolResults(messages: OpenAIChatMessage[]): string {
-  const toolMessages = messages.filter((m) => m.role === 'tool');
+export function serializeToolResults(messages: OpenAIChatMessage[], latestRoundOnly = false): string {
+  // On a thread that already holds the conversation, every tool result before the engine's most
+  // recent assistant turn is already in the transcript. Re-serializing them costs the whole
+  // history again on every hop, so the prompt grows quadratically across a tool loop: with a
+  // 30k-character batch per round, hop 10 re-sends ~300k characters of results the engine has
+  // already seen. Scoping to the results that answer the latest round is what keeps it linear.
+  const scoped = latestRoundOnly ? messages.slice(messages.map((m) => m.role).lastIndexOf('assistant') + 1) : messages;
+  const toolMessages = scoped.filter((m) => m.role === 'tool');
   if (!toolMessages.length) return '';
 
   const results = toolMessages
@@ -401,6 +407,13 @@ export interface ExtractedMessage {
 export function extractUserMessage(
   messages: OpenAIChatMessage[],
   headers?: Record<string, string | string[] | undefined>,
+  /**
+   * Whether the engine's conversation already holds everything up to the caller's latest tool
+   * round. Only meaningful for engines that resume a native conversation and only once the
+   * conversation id has been captured — see nativeThreadIsLive(). Defaults to false so any caller
+   * that cannot establish that keeps the previous behaviour of sending every result.
+   */
+  threadHasHistory = false,
 ): ExtractedMessage {
   if (!messages || messages.length === 0) {
     throw new Error('messages array is empty');
@@ -430,7 +443,7 @@ export function extractUserMessage(
   // and the old tool results are already in the CLI's history.
   const lastNonSystem = [...messages].reverse().find((m) => m.role !== 'system');
   if (lastNonSystem?.role === 'tool') {
-    const toolResultBlock = serializeToolResults(messages);
+    const toolResultBlock = serializeToolResults(messages, threadHasHistory);
     const userMessages = messages.filter((m) => m.role === 'user');
     const lastUserText = userMessages.length > 0 ? textOf(userMessages[userMessages.length - 1]) : '';
     const userMessage = lastUserText ? `${toolResultBlock}\n\n${lastUserText}` : toolResultBlock;
@@ -611,18 +624,33 @@ export async function handleChatCompletion(
   const sessionName = sessionNameFromKey(sessionKey);
   const isStreaming = request.stream === true;
 
+  // Resolved before extracting, because the extraction needs to know whether the engine's
+  // conversation already holds the earlier tool results. In the tool-loop branch
+  // `isNewConversation` is always false, so there `needsCreate` reduces to `!sessionExists` and
+  // this is the same predicate the create path uses further down.
+  const existingSessions = manager.listSessions().map((s) => s.name);
+  const sessionExists = existingSessions.includes(sessionName);
+  let threadHasHistory = false;
+  if (sessionExists && engineHasNativeConversation(engine)) {
+    try {
+      threadHasHistory = nativeThreadIsLive(engine, manager.getStatus(sessionName).stats);
+    } catch {
+      threadHasHistory = false;
+    }
+  }
+
   let extracted: ExtractedMessage;
   try {
-    extracted = extractUserMessage(request.messages, headers as Record<string, string | string[] | undefined>);
+    extracted = extractUserMessage(
+      request.messages,
+      headers as Record<string, string | string[] | undefined>,
+      threadHasHistory,
+    );
   } catch (err) {
     res.writeHead(400, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: { message: (err as Error).message, type: 'invalid_request_error' } }));
     return;
   }
-
-  // Check if session exists
-  const existingSessions = manager.listSessions().map((s) => s.name);
-  const sessionExists = existingSessions.includes(sessionName);
 
   // If new conversation detected and session exists, stop old one first
   if (extracted.isNewConversation && sessionExists) {


### PR DESCRIPTION
> **Stacked on #76.** The diff shown here includes that PR's commit; only the second commit belongs to this one. Happy to rebase once #76 lands or is closed.

## The problem

`serializeToolResults()` walks the entire messages array on every call, so each hop of a tool loop re-sends the loop's whole result history.

For engines that resume a native conversation that history is already in the transcript, so the cost compounds. With a 30k-character batch per round:

| hop | results actually new | results serialized |
|---|---|---|
| 1 | 30k | 30k |
| 5 | 30k | 150k |
| 10 | 30k | 300k |

The prompt grows quadratically in the number of rounds while the useful content grows linearly. In our deployment this was the dominant term in long tool loops — the ones that overflow the window — and measured as the larger of the two effects we chased, ahead of the system-prompt re-send.

## The change

Scope the results to the round that answers the engine's most recent assistant turn:

```ts
const scoped = latestRoundOnly ? messages.slice(messages.map((m) => m.role).lastIndexOf('assistant') + 1) : messages;
```

`latestRoundOnly` is only true when the conversation is known to hold the rest — the `nativeThreadIsLive()` predicate from #76. Everything else keeps the current behaviour, so the failure direction stays "send too much", never "lose context".

No per-session state: which results are new is already implied by the transcript shape the caller sends.

## Why it is safe on a fresh session

The scoping is gated on `sessionExists && engineHasNativeConversation(engine) && nativeThreadIsLive(...)`. A brand-new session — including one recreated after a restart — has no id captured, so it takes the full path and receives every result. That is exactly the case #76 exists to detect.

## One ordering change

`sessionExists` moves a few lines up, above the `extractUserMessage()` call, so the extraction can see it. Safe because:

- `manager.listSessions()` does not depend on the extraction.
- In the tool-loop branch `extractUserMessage()` returns `isNewConversation: false` unconditionally, so `needsCreate` there reduces to `!sessionExists` — the same predicate the create path uses below.

## Behaviour

| situation | before | after |
|---|---|---|
| resumed thread, mid tool loop | all results, every hop | results of the latest round |
| resumed thread, first tool round | all results | all results — unchanged |
| session in map, no id captured | all results | all results — unchanged |
| fresh session | all results | all results — unchanged |
| `claude`, one-shot engines | all results | all results — unchanged |

## Tests

Five cases on the scoping, including the two boundaries that would silently lose context if the slice were wrong: a tool round with no preceding assistant turn keeps everything, and a trailing assistant turn with no results after it yields an empty block.

`npm run build`, `npm run lint`, `npm run format:check` clean; `vitest run` green at **905/905** across 58 files.
