### PR TITLE
fix(agy): forward reasoning effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on engines that estimate token counts the cap is best-effort — see
   `observability.md`.
 
+- **Antigravity ignored the engine-agnostic reasoning-effort setting.** The
+  first-class `agy` adapter now forwards session defaults and per-turn overrides
+  as `--effort`. Since agy accepts only `low`, `medium`, and `high`, the shared
+  `max`/`xhigh` aliases clamp to `high`. `auto` resolves unsuffixed base-model
+  slugs to `high` because the current CLI requires an explicit selection, while
+  already-qualified `-low`/`-medium`/`-high` slugs keep their own effort. A
+  conflicting per-turn override strips the old suffix before passing the new
+  effort, avoiding agy's model/effort conflict error.
+
 - **Claude engine sessions failed with `Invalid API key` when the host process
   carried a proxy-scoped `ANTHROPIC_API_KEY`.** The spawn environment inherits
   `process.env`, so a key meant for a local proxy leaked into `claude` child

--- a/skills/references/multi-engine.md
+++ b/skills/references/multi-engine.md
@@ -13,7 +13,7 @@ SessionManager
 ├── engine: 'codex-app' → PersistentCodexAppServerSession
 │   └── Wraps: codex app-server --listen stdio:// (long-running JSON-RPC; required for /goal)
 ├── engine: 'agy'       → PersistentAgySession
-│   └── Wraps: agy -p (Google Antigravity CLI, per-message spawning, plain-text output)
+│   └── Wraps: agy -p (Google Antigravity CLI, per-message spawning, stream-json output)
 ├── engine: 'cursor'    → PersistentCursorSession
 │   └── Wraps: agent -p --force --trust --output-format stream-json (per-message spawning)
 ├── engine: 'opencode'  → PersistentOpencodeSession
@@ -112,16 +112,26 @@ await manager.startSession({
 
 Wraps Google's **Antigravity CLI** (`agy`) — the successor to Gemini CLI (consumer
 Gemini CLI tiers stopped serving 2026-06-18). Each `send()` spawns a new process
-in print mode. Verified against `agy` **1.1.1**.
+in print mode. Verified against `agy` **1.1.13**.
 
 - One-shot execution per message (no persistent subprocess)
-- **Plain-text output** — agy has no structured/stream-json mode, so stdout is
-  forwarded as streaming text and **token counts are estimated** (~4 chars/token)
-- **Real conversation continuity**: agy logs `Created conversation <uuid>` to its
-  log file; the engine passes a private `--log-file`, harvests the ID after the
-  first turn, and resumes with `--conversation <id>` on subsequent sends. Seed it
+- **Structured output and real usage** — `--output-format stream-json` emits an
+  `init` event with the conversation id, progress events, and a final `result`
+  with the response plus input/output/cache-read token counts. Plain text and
+  estimated usage remain as compatibility fallbacks when a result event is absent.
+- **Real conversation continuity**: the engine captures the id from stream-json
+  and resumes with `--conversation <id>` on later sends. A private `--log-file`
+  scrape remains as a fallback for turns that die before emitting `init`. Seed it
   externally via `resumeSessionId` (bare UUID only); read it back from
-  `getStats().agyConversationId`
+  `getStats().agyConversationId`.
+- **Reasoning effort**: session `effort` and per-turn `session_send` overrides map
+  to `--effort`. agy accepts `low`, `medium`, and `high`; engine-wide `max` and
+  `xhigh` clamp to `high`. agy 1.1.13 requires an effort with unsuffixed base
+  slugs such as `gemini-3.7-flash`, so `auto` resolves those to `high`; a model
+  already ending in `-low`, `-medium`, or `-high` keeps that qualified effort.
+  Per-turn overrides also work with qualified slugs: the adapter removes a
+  conflicting suffix before passing the new `--effort`, avoiding agy's conflict
+  error.
 - Permission modes: `bypassPermissions` → `--dangerously-skip-permissions`,
   `default` → `--sandbox` (terminal-restricted), and
   `sandboxMode: 'read-only'` → `--mode plan` (takes precedence). Other modes
@@ -144,6 +154,7 @@ await manager.startSession({
   name: 'antigravity-task',
   engine: 'agy',
   model: 'gemini-3.5-flash',
+  effort: 'high',
   cwd: '/project',
 });
 ```

--- a/src/__tests__/agy-session.test.ts
+++ b/src/__tests__/agy-session.test.ts
@@ -1,9 +1,9 @@
 /**
  * Unit tests for PersistentAgySession
  *
- * Tests flag construction, plain-text collection, conversation-ID harvesting
- * from the agy log file, timeout coherence, and stats tracking. Uses vitest
- * mocks for child_process.spawn to avoid spawning real processes.
+ * Tests flag construction, stream-json/plain-text collection, conversation-ID
+ * capture, timeout coherence, and stats tracking. Uses vitest mocks for
+ * child_process.spawn to avoid spawning real processes.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -217,6 +217,139 @@ describe('PersistentAgySession', () => {
       const idx = spawnArgs.indexOf('--model');
       expect(idx).toBeGreaterThan(-1);
       expect(spawnArgs[idx + 1]).toBe('gemini-3.1-pro');
+    });
+
+    it('passes the session reasoning effort to agy', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        model: 'gemini-3.5-flash',
+        effort: 'high',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      const idx = spawnArgs.indexOf('--effort');
+      expect(idx).toBeGreaterThan(-1);
+      expect(spawnArgs[idx + 1]).toBe('high');
+    });
+
+    it('lets a per-turn reasoning effort override the session default', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        effort: 'high',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true, effort: 'medium' });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      const idx = spawnArgs.indexOf('--effort');
+      expect(spawnArgs[idx + 1]).toBe('medium');
+      expect(spawnArgs.filter((arg) => arg === '--effort')).toHaveLength(1);
+    });
+
+    it.each(['max', 'xhigh'] as const)('maps engine-wide %s effort to agy high', async (effort) => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        effort,
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      const idx = spawnArgs.indexOf('--effort');
+      expect(spawnArgs[idx + 1]).toBe('high');
+    });
+
+    it('uses agy high for an unsuffixed model when effort is auto', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        model: 'gemini-3.5-flash',
+        effort: 'auto',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      const idx = spawnArgs.indexOf('--effort');
+      expect(spawnArgs[idx + 1]).toBe('high');
+    });
+
+    it('omits --effort for auto when no model is selected', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        effort: 'auto',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(spawnArgs).not.toContain('--effort');
+    });
+
+    it('does not duplicate effort for an effort-qualified model slug', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        model: 'gemini-3.7-flash-high',
+        effort: 'auto',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      expect(spawnArgs).toContain('gemini-3.7-flash-high');
+      expect(spawnArgs).not.toContain('--effort');
+    });
+
+    it('strips a conflicting model effort suffix for a per-turn override', async () => {
+      const session = new PersistentAgySession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+        model: 'gemini-3.7-flash-low',
+        effort: 'auto',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true, effort: 'high' });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+      const modelIdx = spawnArgs.indexOf('--model');
+      const effortIdx = spawnArgs.indexOf('--effort');
+      expect(spawnArgs[modelIdx + 1]).toBe('gemini-3.7-flash');
+      expect(spawnArgs[effortIdx + 1]).toBe('high');
     });
   });
 

--- a/src/persistent-agy-session.ts
+++ b/src/persistent-agy-session.ts
@@ -31,7 +31,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import type { SessionConfig, SessionSendOptions, StreamEvent, TurnResult } from './types.js';
+import type { EffortLevel, SessionConfig, SessionSendOptions, StreamEvent, TurnResult } from './types.js';
 import { estimateTokens } from './models.js';
 import { sanitizeSecrets } from './sanitize.js';
 import { extractCreatedAgyConversationId, isAgyConversationId } from './agy-conversation.js';
@@ -100,10 +100,10 @@ export class PersistentAgySession extends BaseOneShotSession {
   /**
    * Build the agy spawn args for this turn.
    *
-   * First turn:    `agy -p <msg> --log-file <tmp> [--sandbox|--dangerously-skip-permissions] [--model M] --print-timeout Ns`
+   * First turn:    `agy -p <msg> --log-file <tmp> [--sandbox|--dangerously-skip-permissions] [--model M] [--effort E] --print-timeout Ns`
    * Resume turns:  same + `--conversation <id>`
    */
-  private _buildArgs(message: string, timeoutMs: number): string[] {
+  private _buildArgs(message: string, timeoutMs: number, turnEffort?: EffortLevel): string[] {
     // stream-json gives the conversation id up front, progress events while the
     // turn runs, and a final `result` carrying the answer plus real token usage.
     // Before this, the wrapper read plain text, scraped the id out of the log
@@ -129,9 +129,35 @@ export class PersistentAgySession extends BaseOneShotSession {
     // Use the SessionManager-resolved model when available so documented
     // aliases (agy-pro → gemini-3.1-pro) do not silently fall back to agy's
     // default model.
+    // agy 1.1.5+ exposes reasoning variants through --effort. Its accepted
+    // values are narrower than the engine-agnostic EffortLevel union: only
+    // low|medium|high are valid. Preserve the caller's intent by clamping the
+    // two higher aliases to agy's ceiling. A per-turn override wins over the
+    // session default, matching session_send's documented contract.
+    //
+    // Current agy also requires an effort when --model is an unsuffixed base
+    // slug, so the provider-specific meaning of auto is high in that case. A
+    // fully-qualified `-low|-medium|-high` slug already carries its effort and
+    // needs no flag. If a caller overrides such a slug to a different effort,
+    // strip the suffix first: agy rejects conflicting --model/--effort pairs.
     const configuredModel = this.options.resolvedModel || this.options.model;
-    const model = configuredModel ? this.resolveModel(configuredModel.replace(/^agy\//, '')) : undefined;
+    let model = configuredModel ? this.resolveModel(configuredModel.replace(/^agy\//, '')) : undefined;
+    const requestedEffort = turnEffort ?? this.options.effort;
+    const explicitEffort =
+      requestedEffort === 'max' || requestedEffort === 'xhigh'
+        ? 'high'
+        : requestedEffort === 'auto'
+          ? undefined
+          : requestedEffort;
+    const modelEffortMatch = model?.match(/-(low|medium|high)$/);
+    if (model && modelEffortMatch && explicitEffort && modelEffortMatch[1] !== explicitEffort) {
+      model = model.slice(0, -modelEffortMatch[0].length);
+    }
+    const effort = explicitEffort ?? (model && !modelEffortMatch ? 'high' : undefined);
+
     if (model) args.push('--model', model);
+    if (effort) args.push('--effort', effort);
+
     if (this.agyConversationId) args.push('--conversation', this.agyConversationId);
 
     // agy enforces its own print-mode timeout (default 5m). Derive it from the
@@ -174,7 +200,7 @@ export class PersistentAgySession extends BaseOneShotSession {
 
   protected _run(message: string, options: SessionSendOptions): Promise<TurnResult> {
     const timeout = options.timeout || 300_000;
-    const args = this._buildArgs(message, timeout);
+    const args = this._buildArgs(message, timeout, options.effort);
 
     return new Promise<TurnResult>((resolve, reject) => {
       let resultText = '';


### PR DESCRIPTION
## Summary

- forward session-default and per-turn reasoning effort to Antigravity through `--effort`
- normalize the shared `max` and `xhigh` levels to the agy ceiling of `high`
- make provider `auto` resolve unsuffixed model slugs to `high`, while preserving already-qualified model slugs
- strip a conflicting effort suffix when a per-turn override selects another level
- refresh the Antigravity documentation for stream-json, real token usage, conversation IDs, and current agy 1.1.13 behavior

## Why

agy added `--effort` in 1.1.5. The first-class adapter accepted the engine-agnostic effort setting but never forwarded it. On agy 1.1.13, an unsuffixed model such as `gemini-3.7-flash` now requires an effort, while a qualified model such as `gemini-3.7-flash-low` rejects a conflicting `--effort high` pair.

## Verification

- `npm test` — 59 files, 959 tests passed
- `npm run lint`
- `npm run format:check`
- `npm run build`
- live agy 1.1.13 smoke: base model + auto resolved to `gemini-3.7-flash-high`
- live agy 1.1.13 smoke: `gemini-3.7-flash-low` + per-turn high resolved to `gemini-3.7-flash-high`
