### PR TITLE
feat(stats): add turnsSucceeded, and read the run ledger's `ok` from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,85 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`turnsSucceeded` on `SessionStats` — `turns` never meant the turn
+  succeeded.** It is incremented at ten sites that mean three different things:
+  the `user` echo of a message going out before any result exists (`claude`, and
+  a persistent `custom`), reaching process close whatever the outcome (the five
+  `BaseOneShotSession` engines plus a one-shot `custom`), and a `turn/completed`
+  notification that may itself report a non-completed status (`codex-app`). None
+  of them is the reading its writer's name — `_recordTurnComplete()` — invites.
+
+  `turns` keeps its meaning and is now documented as "turns that reached the
+  engine, whatever their outcome". `turnsSucceeded` counts only the ones the
+  engine reported as successful, and the predicate is the engine's own terminal
+  verdict rather than the exit code: `codex` fails a turn that emits
+  `turn.failed` while exiting 0, `agy` requires `SUCCESS` *and* a zero exit,
+  `gemini` succeeds on exit 53 (its turn limit resolves), `codex-app` requires
+  `status: 'completed'`, and `opencode` refuses a turn on purpose when read-only
+  enforcement did not load. On the one-shot engines the counter and that turn's
+  `stop_reason` come from one expression, so they cannot disagree; `gemini` and
+  `codex-app` keep their own `stop_reason` mapping (`turn_limit`, `interrupted`)
+  and the counter is the stricter of the two.
+
+  **`turns` is not one-per-send on every engine, so the difference between the
+  two counters is the failure count on the one-shot engines only.** On `claude`
+  and a persistent `custom`, `turns` counts `user` events and the CLI emits one
+  per tool-result batch as well as the prompt echo — a send that used eight tools
+  counts nine. `turnsSucceeded` *is* one-per-send everywhere, so compare it
+  against sends there, not against `turns`. Measured against claude-code
+  stream-json, not inferred.
+
+  Exposed as `turns_succeeded` on `/v1/sessions` (openai-compat sessions) and in
+  `health().details`.
+
+### Breaking
+
+- **`SessionStats.turnsSucceeded` is required, not optional.** Source-breaking
+  for a TypeScript consumer that builds a `SessionStats` object of its own
+  (implementing `ISession`, or a test double); runtime consumers reading the
+  field are unaffected. Required on purpose: it makes `tsc` enumerate the four
+  places in `src/` that own a stats object instead of leaving one silently
+  `undefined`.
+
+- **`BaseOneShotSession._recordTurnComplete()` now takes a required `ok`
+  argument.** The class is exported, so the `protected` method is part of the
+  published subclassing surface: an out-of-tree engine subclass calling it with
+  no argument fails to compile, and in plain JS would record every turn as
+  failed.
+
+### Fixed
+
+- **A turn the engine itself reported as failed could be recorded as successful
+  work in the run ledger.** The row's `ok` was "nothing was thrown", which is a
+  weaker statement than the engine's own verdict, and three cases resolved
+  cleanly while having failed: `agy` exiting 0 with a non-SUCCESS status, a
+  `codex-app` turn cancelled through `interrupt()` (its `turn/completed` reports
+  `status: 'interrupted'`), and a `claude` or persistent `custom` CLI that dies
+  mid-turn and resolves with `stop_reason: 'process_exit'`. `ok` now reads the
+  session's own counter — the row is successful when `turnsSucceeded` moved — so
+  the ledger and `/v1/sessions` cannot disagree about the same turn. When the
+  counter cannot be read at all (a `getStats()` that throws), it falls back to
+  the old meaning rather than reporting a telemetry failure as a turn failure.
+
+  The cost of a failed turn still counts against `maxBudgetUsd`: that gate reads
+  `costUsd` and has never distinguished successful from failed work. What changes
+  is only that the row records the outcome honestly.
+
+- **`codex-app` counted an interrupted turn as a completed one.** The engine's
+  `TurnStatus` is `completed | interrupted | failed | inProgress`, and
+  `interrupt()` on that session produces `interrupted` on purpose, so testing for
+  the absence of `failed` treated a cancellation as a success.
+
+- **`agy` could report `SUCCESS` and still exit non-zero, and a failure it had
+  already reported could be erased by a later `SUCCESS` in the same turn.** The
+  status is now recorded sticky-on-failure and the exit code stays in the
+  outcome expression, so a turn whose promise rejects is never counted as one
+  that succeeded.
+
 ## [4.14.1] - 2026-08-18
 
 ### Fixed

--- a/skills/references/multi-engine.md
+++ b/skills/references/multi-engine.md
@@ -263,6 +263,10 @@ interface ISession {
 }
 ```
 
+`SessionStats` requires `turnsSucceeded` as well as `turns`, so an engine that
+implements this interface has to say which of its turns succeeded — the exit code
+is not the answer on every engine. See "Stats & Monitoring" in `sessions.md`.
+
 ## Team Tools Across Engines
 
 Team tools (`team_list`, `team_send`) operate on the same virtual-team layer for **every** engine: the "team" is the set of all active sessions managed by SessionManager.

--- a/skills/references/observability.md
+++ b/skills/references/observability.md
@@ -43,7 +43,7 @@ every engine passes through.
 | `tokensEstimated` | `true` when the counts came from `estimateTokens()` (see below) |
 | `durationMs` | Wall-clock for the turn |
 | `toolCalls` / `toolErrors` | Per-turn deltas |
-| `ok` | `false` for a turn that threw or reported `is_error` |
+| `ok` | `false` for a turn that threw, or that the session's own `turnsSucceeded` counter did not count (see `sessions.md`). Falls back to "nothing was thrown" when the counter cannot be read |
 | `error` | Failure text, truncated to 500 chars |
 | `parent` | council id / fanout id / autoloop run id, when the turn belongs to one |
 

--- a/skills/references/openai-compat.md
+++ b/skills/references/openai-compat.md
@@ -148,7 +148,8 @@ Sample response:
       "model": "claude-opus-4-6",
       "cwd": "/home/user/projects",
       "created": "2026-04-09T03:12:18.441Z",
-      "turns": 14,
+      "turns": 68,
+      "turns_succeeded": 14,
       "tokens_in": 248312,
       "tokens_out": 38201,
       "cached_tokens": 198104,
@@ -158,6 +159,11 @@ Sample response:
   ]
 }
 ```
+
+`turns_succeeded` is one per request; `turns` is not comparable to it on these
+sessions — the Claude CLI emits a `user` event per tool-result batch and `turns`
+counts those, so the gap above is tool use, not failures. Compare
+`turns_succeeded` against your own request count.
 
 The single most important field is **`cached_tokens`**. If it grows turn-over-turn, the persistent CLI is being reused and Anthropic prompt caching is warming. If it stays at 0, something is killing the session every turn — check that no client is sending `X-Session-Reset` unintentionally and that `OPENAI_COMPAT_NEW_CONVO_HEURISTIC` is not set when it shouldn't be.
 

--- a/skills/references/sessions.md
+++ b/skills/references/sessions.md
@@ -138,6 +138,29 @@ tokens the session has been billed for in total, which only ever grows.
 (`codex`, `agy`, `cursor`, `opencode`); those sessions log a warning the first
 time it is called.
 
+`stats.turns` and `stats.turnsSucceeded` are the same kind of distinction.
+`turns` counts turns that reached the engine, whatever their outcome, including
+the ones that then failed. `turnsSucceeded` counts only the ones the engine
+reported as successful, and it is one per send on every engine.
+
+**The two are only comparable on the one-shot engines.** There `turns` is also
+one per send, so the difference between them is the failure count. On `claude`
+and a persistent `custom`, `turns` counts `user` events — and the CLI emits one
+per tool-result batch as well as the prompt echo, so a send that used eight tools
+counts nine. Compare `turnsSucceeded` against the number of sends there, never
+against `turns`.
+
+Which outcome counts as a success is the engine's own verdict, not the exit
+code's: `codex` fails a turn that emits `turn.failed` while exiting 0, `agy`
+requires a `SUCCESS` status *and* a zero exit (it can report success and then die
+in cleanup), `gemini` succeeds on exit 53 because its turn limit resolves,
+`codex-app` requires `status: 'completed'` so a turn cancelled through
+`interrupt()` does not count, and `opencode` refuses a turn on purpose when
+read-only enforcement did not load.
+
+The run ledger's `ok` reads this same counter, so a turn cannot be a failure on
+`/v1/sessions` and a success in `clawo runs`.
+
 ### Cost Tracking
 
 ```typescript

--- a/src/__tests__/agy-session.test.ts
+++ b/src/__tests__/agy-session.test.ts
@@ -777,4 +777,95 @@ describe('PersistentAgySession', () => {
       expect(logs.some((l) => l.includes('sk-proj-abcdef'))).toBe(false);
     });
   });
+
+  // ─── turnsSucceeded ─────────────────────────────────────────────────────
+  //
+  // agy is the engine where the exit code is the weakest of the three signals: it
+  // can exit 0 while its own result event reports a non-SUCCESS status. That turn
+  // resolves — so it used to reach the caller, and the run ledger, as a success.
+  describe('turnsSucceeded', () => {
+    it('does not count exit 0 with a non-SUCCESS status, and says so in the event', async () => {
+      const session = new PersistentAgySession({ name: 'test', cwd: '/tmp', permissionMode: 'default' });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      feedText(
+        mockProc,
+        JSON.stringify({
+          event: 'result',
+          // No `error` field: nothing but the status marks this turn as failed.
+          result: { conversation_id: 'c1', status: 'STOPPED', response: 'partial' },
+        }) + '\n',
+      );
+      setTimeout(() => closeProc(mockProc, 0), 10);
+
+      // It resolves — which is exactly why the status has to be read.
+      const result = (await sendPromise) as { text: string; event: { stop_reason: string } };
+      expect(result.event.stop_reason).toBe('error');
+
+      const stats = session.getStats();
+      expect(stats.turns).toBe(1);
+      expect(stats.turnsSucceeded).toBe(0);
+    });
+
+    // Regression guard: agy can report SUCCESS and still exit non-zero (it answers,
+    // then dies in cleanup). That turn's promise REJECTS, so counting it as succeeded
+    // would put the counter and the caller's outcome in direct contradiction.
+    it('does not count a SUCCESS status that exits non-zero', async () => {
+      const session = new PersistentAgySession({ name: 'test', cwd: '/tmp', permissionMode: 'default' });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      feedText(
+        mockProc,
+        JSON.stringify({ event: 'result', result: { conversation_id: 'c1', status: 'SUCCESS', response: 'OK' } }) +
+          '\n',
+      );
+      setTimeout(() => closeProc(mockProc, 1), 10);
+      await expect(sendPromise).rejects.toThrow(/exited with code 1/);
+
+      const stats = session.getStats();
+      expect(stats.turns).toBe(1);
+      expect(stats.turnsSucceeded).toBe(0);
+    });
+
+    // A failure agy already reported must not be erased by a later SUCCESS in the same
+    // turn: the status is recorded sticky.
+    it('does not count a turn whose earlier result event reported a failure', async () => {
+      const session = new PersistentAgySession({ name: 'test', cwd: '/tmp', permissionMode: 'default' });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      feedText(
+        mockProc,
+        JSON.stringify({ event: 'result', result: { conversation_id: 'c1', status: 'STOPPED', response: 'partial' } }) +
+          '\n' +
+          JSON.stringify({ event: 'result', result: { conversation_id: 'c1', status: 'SUCCESS', response: 'OK' } }) +
+          '\n',
+      );
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      const result = (await sendPromise) as { event: { stop_reason: string } };
+
+      expect(result.event.stop_reason).toBe('error');
+      expect(session.getStats().turnsSucceeded).toBe(0);
+    });
+
+    it('counts a SUCCESS status', async () => {
+      const session = new PersistentAgySession({ name: 'test', cwd: '/tmp', permissionMode: 'default' });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      feedText(
+        mockProc,
+        JSON.stringify({ event: 'result', result: { conversation_id: 'c1', status: 'SUCCESS', response: 'OK' } }) +
+          '\n',
+      );
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const stats = session.getStats();
+      expect(stats.turns).toBe(1);
+      expect(stats.turnsSucceeded).toBe(1);
+    });
+  });
 });

--- a/src/__tests__/circuit-breaker.test.ts
+++ b/src/__tests__/circuit-breaker.test.ts
@@ -53,6 +53,7 @@ class MockSession extends EventEmitter implements ISession {
   getStats(): SessionStats & { sessionId?: string; uptime: number } {
     return {
       turns: 0,
+      turnsSucceeded: 0,
       toolCalls: 0,
       toolErrors: 0,
       tokensIn: 0,

--- a/src/__tests__/codex-app-session.test.ts
+++ b/src/__tests__/codex-app-session.test.ts
@@ -187,6 +187,45 @@ describe('PersistentCodexAppServerSession v2 RPCs', () => {
     }, 5);
     await expect(p).rejects.toThrow(/turn failed/i);
     expect(session.getStats().toolErrors).toBe(1);
+    // The notification counts the turn and reports that it failed, in the same payload.
+    expect(session.getStats().turns).toBe(1);
+    expect(session.getStats().turnsSucceeded).toBe(0);
+  });
+
+  // The engine's TurnStatus is `completed | interrupted | failed | inProgress`, and
+  // `interrupt()` on this class produces `interrupted` on purpose. Testing for the
+  // absence of `failed` counted a cancelled turn as a success.
+  it('does not count an interrupted turn as succeeded, and counts a completed one', async () => {
+    const proc = createMockProc(defaultResponder());
+    const session = await startSession(proc);
+
+    const p1 = session.send('do it', { waitForComplete: true });
+    setTimeout(() => {
+      proc.stdout.push(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'turn/completed',
+          params: { threadId: 't1', turn: { id: 'turnI', status: 'interrupted' } },
+        }) + '\n',
+      );
+    }, 5);
+    await p1.catch(() => undefined);
+    expect(session.getStats().turns).toBe(1);
+    expect(session.getStats().turnsSucceeded).toBe(0);
+
+    const p2 = session.send('do it again', { waitForComplete: true });
+    setTimeout(() => {
+      proc.stdout.push(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'turn/completed',
+          params: { threadId: 't1', turn: { id: 'turnC', status: 'completed' } },
+        }) + '\n',
+      );
+    }, 5);
+    await p2;
+    expect(session.getStats().turns).toBe(2);
+    expect(session.getStats().turnsSucceeded).toBe(1);
   });
 
   it('steer() falls back to a normal turn when idle (no in-flight turn)', async () => {

--- a/src/__tests__/codex-session.test.ts
+++ b/src/__tests__/codex-session.test.ts
@@ -464,4 +464,46 @@ describe('PersistentCodexSession', () => {
     expect(logs.filter((l) => l.includes('does not support compaction'))).toHaveLength(1);
     session.stop();
   });
+
+  // `turns` counts turns that reached the engine; `turnsSucceeded` counts the ones
+  // that succeeded. A `turn.failed` with exit 0 is the case that separates them:
+  // the process exits cleanly, so nothing in the exit code says the turn failed.
+  describe('turnsSucceeded', () => {
+    it('does not count a turn.failed that exits 0', async () => {
+      const session = new PersistentCodexSession({ name: 'test', cwd: '/tmp' });
+      await session.start();
+
+      const p = session.send('hi', { waitForComplete: true });
+      setTimeout(() => {
+        mockProc.stdout.push(JSON.stringify({ type: 'thread.started', thread_id: 'thread-failed' }) + '\n');
+        mockProc.stdout.push(
+          JSON.stringify({ type: 'turn.failed', error: { message: 'model refused the request' } }) + '\n',
+        );
+        mockProc.stdout.push(null);
+        mockProc.emit('close', 0);
+      }, 10);
+      await expect(p).rejects.toThrow('model refused the request');
+
+      const stats = session.getStats();
+      expect(stats.turns).toBe(1);
+      expect(stats.turnsSucceeded).toBe(0);
+      session.stop();
+    });
+
+    // Positive control: without this, the assertion above passes on a counter that
+    // is simply never incremented.
+    it('counts a clean turn', async () => {
+      const session = new PersistentCodexSession({ name: 'test', cwd: '/tmp' });
+      await session.start();
+
+      const p = session.send('hi', { waitForComplete: true });
+      setTimeout(() => runTurn(mockProc, 'thread-ok'), 10);
+      await p;
+
+      const stats = session.getStats();
+      expect(stats.turns).toBe(1);
+      expect(stats.turnsSucceeded).toBe(1);
+      session.stop();
+    });
+  });
 });

--- a/src/__tests__/cursor-session.test.ts
+++ b/src/__tests__/cursor-session.test.ts
@@ -454,4 +454,26 @@ describe('PersistentCursorSession', () => {
       expect(logs.some((l) => l.includes('sk-12345'))).toBe(false);
     });
   });
+
+  describe('turnsSucceeded', () => {
+    it('counts a clean turn and not a non-zero exit', async () => {
+      const session = new PersistentCursorSession({ name: 'test', cwd: '/tmp', permissionMode: 'bypassPermissions' });
+      await session.start();
+
+      const p1 = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await p1;
+      expect(session.getStats().turnsSucceeded).toBe(1);
+
+      const proc2 = createMockProcess();
+      mockSpawn.mockReturnValue(proc2);
+      const p2 = session.send('again', { waitForComplete: true });
+      setTimeout(() => closeProc(proc2, 1), 10);
+      await expect(p2).rejects.toThrow();
+
+      const stats = session.getStats();
+      expect(stats.turns).toBe(2);
+      expect(stats.turnsSucceeded).toBe(1);
+    });
+  });
 });

--- a/src/__tests__/gemini-session.test.ts
+++ b/src/__tests__/gemini-session.test.ts
@@ -274,6 +274,10 @@ describe('PersistentGeminiSession', () => {
 
       const result = await sendPromise;
       expect('event' in result && (result.event as Record<string, unknown>).stop_reason).toBe('turn_limit');
+      // The turn limit resolves, so it is a completion: it counts as succeeded.
+      const stats = session.getStats();
+      expect(stats.turns).toBe(1);
+      expect(stats.turnsSucceeded).toBe(1);
     });
 
     it('rejects on non-zero exit with no output', async () => {

--- a/src/__tests__/opencode-session.test.ts
+++ b/src/__tests__/opencode-session.test.ts
@@ -230,6 +230,29 @@ describe('PersistentOpencodeSession', () => {
       }, 10);
 
       await expect(sendPromise).rejects.toThrow(/read-only enforcement failed/i);
+      // The turn reached the engine and was refused on purpose: counted, not succeeded.
+      const stats = session.getStats();
+      expect(stats.turns).toBe(1);
+      expect(stats.turnsSucceeded).toBe(0);
+    });
+
+    // Positive control for the refusal above, and the only cover for this engine's
+    // normal close path.
+    it('counts a clean turn', async () => {
+      const session = new PersistentOpencodeSession({
+        name: 'test',
+        cwd: '/tmp',
+        permissionMode: 'bypassPermissions',
+      });
+      await session.start();
+
+      const sendPromise = session.send('hello', { waitForComplete: true });
+      setTimeout(() => closeProc(mockProc, 0), 10);
+      await sendPromise;
+
+      const stats = session.getStats();
+      expect(stats.turns).toBe(1);
+      expect(stats.turnsSucceeded).toBe(1);
     });
 
     it('passes --model only when model contains "/"', async () => {

--- a/src/__tests__/persistent-session.test.ts
+++ b/src/__tests__/persistent-session.test.ts
@@ -502,6 +502,22 @@ describe('PersistentClaudeSession', () => {
       const event = { type: 'user', message: { role: 'user', content: 'hi' } };
       mockProc.stdout.emit('data', Buffer.from(JSON.stringify(event) + '\n'));
       expect(session.stats.turns).toBe(1);
+      // The echo of the message going out: no result exists yet, so nothing has
+      // succeeded. This is what keeps `turnsSucceeded` from inheriting `turns`'
+      // meaning here.
+      expect(session.stats.turnsSucceeded).toBe(0);
+    });
+
+    it('counts turnsSucceeded on a clean result and not on an is_error one', () => {
+      const ok = { type: 'result', result: 'done' };
+      mockProc.stdout.emit('data', Buffer.from(JSON.stringify(ok) + '\n'));
+      expect(session.stats.turnsSucceeded).toBe(1);
+
+      // The CLI reports turn-level failures (invalid --model, auth loss) as a
+      // result event carrying is_error.
+      const bad = { type: 'result', result: 'model not found', is_error: true };
+      mockProc.stdout.emit('data', Buffer.from(JSON.stringify(bad) + '\n'));
+      expect(session.stats.turnsSucceeded).toBe(1);
     });
 
     it('emits RESULT and TURN_COMPLETE on result event', () => {

--- a/src/__tests__/session-manager-budget.test.ts
+++ b/src/__tests__/session-manager-budget.test.ts
@@ -80,6 +80,7 @@ class CostingSession extends EventEmitter implements ISession {
   getStats(): SessionStats & { sessionId?: string; uptime: number } {
     return {
       turns: this.turns,
+      turnsSucceeded: this.turns,
       toolCalls: this.toolCalls,
       toolErrors: 0,
       tokensIn: this.turns * 100,

--- a/src/__tests__/session-manager.test.ts
+++ b/src/__tests__/session-manager.test.ts
@@ -35,6 +35,10 @@ class MockSession extends EventEmitter implements ISession {
   stopCalled = 0;
   sendCalls: Array<{ message: string | unknown[]; options?: SessionSendOptions }> = [];
   compactCalls: string[] = [];
+  /** Overrides the result event this session resolves with. */
+  nextEvent?: Record<string, unknown>;
+  /** Overrides `turnsSucceeded`, to simulate a turn the engine did not count. */
+  turnsSucceededOverride?: number;
 
   get isReady() {
     return this._isReady;
@@ -81,13 +85,20 @@ class MockSession extends EventEmitter implements ISession {
     }
     return {
       text: `response to: ${typeof message === 'string' ? message : JSON.stringify(message)}`,
-      event: { type: 'result', result: 'done' },
+      event: this.nextEvent ?? { type: 'result', result: 'done' },
     };
+  }
+
+  private _settledSends(): Array<{ message: string | unknown[]; options?: SessionSendOptions }> {
+    return this.sendCalls.filter((c) => c.options?.waitForComplete !== false);
   }
 
   getStats(): SessionStats & { sessionId?: string; uptime: number } {
     return {
-      turns: this.sendCalls.length,
+      // A fire-and-forget send has not settled a turn, so a real engine's counters
+      // have not moved yet either.
+      turns: this._settledSends().length,
+      turnsSucceeded: this.turnsSucceededOverride ?? this._settledSends().length,
       toolCalls: 0,
       toolErrors: 0,
       tokensIn: 100,
@@ -387,6 +398,60 @@ describe('SessionManager', () => {
 
     it('throws for unknown session', async () => {
       await expect(mgr.sendMessage('nope', 'hi')).rejects.toThrow("Session 'nope' not found");
+    });
+
+    // agy resolves with `stop_reason: 'error'` while carrying a usable reply. That
+    // must NOT become `SendResult.error`: openai-compat answers 502 on a non-empty
+    // error and drops the text, and ultraplan discards the plan. The outcome is
+    // recorded in the ledger instead, from the session's own counter.
+    it('records a turn the engine did not count as ok:false without failing the caller', async () => {
+      await mgr.startSession({ name: 'sr-error', cwd: '/tmp' });
+      lastMock().nextEvent = { type: 'result', result: 'agy stopped early', stop_reason: 'error' };
+      lastMock().turnsSucceededOverride = 0;
+      const ledger = vi.mocked((await import('node:fs')).default.appendFileSync);
+      ledger.mockClear();
+
+      const result = await mgr.sendMessage('sr-error', 'hello');
+
+      // The reply still reaches the caller.
+      expect(result.error).toBeUndefined();
+      expect(result.output).toContain('hello');
+      const rows = ledger.mock.calls.map((c) => JSON.parse(String(c[1]))).filter((r) => r.session === 'sr-error');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].ok).toBe(false);
+    });
+
+    // The guard: a session whose getStats() throws leaves both snapshots empty, so the
+    // counter cannot be read. A telemetry failure must not be recorded as a failed turn —
+    // the row falls back to what it meant before, "nothing was thrown".
+    it('keeps ok:true when the counter cannot be read at all', async () => {
+      await mgr.startSession({ name: 'sr-blind', cwd: '/tmp' });
+      lastMock().getStats = () => {
+        throw new Error('engine torn down');
+      };
+      const ledger = vi.mocked((await import('node:fs')).default.appendFileSync);
+      ledger.mockClear();
+
+      await mgr.sendMessage('sr-blind', 'hello');
+
+      const rows = ledger.mock.calls.map((c) => JSON.parse(String(c[1]))).filter((r) => r.session === 'sr-blind');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].ok).toBe(true);
+    });
+
+    // Positive control for the assertion above: the default event still reads as a
+    // success, so `ok: false` above is the classification and not a constant.
+    it('records a clean turn as ok in the ledger', async () => {
+      await mgr.startSession({ name: 'sr-ok', cwd: '/tmp' });
+      const ledger = vi.mocked((await import('node:fs')).default.appendFileSync);
+      ledger.mockClear();
+
+      const result = await mgr.sendMessage('sr-ok', 'hello');
+
+      expect(result.error).toBeUndefined();
+      const rows = ledger.mock.calls.map((c) => JSON.parse(String(c[1]))).filter((r) => r.session === 'sr-ok');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].ok).toBe(true);
     });
 
     it('passes effort and plan options through', async () => {

--- a/src/base-oneshot-session.ts
+++ b/src/base-oneshot-session.ts
@@ -68,6 +68,7 @@ export abstract class BaseOneShotSession extends EventEmitter implements ISessio
   public sessionId?: string;
   protected _stats = {
     turns: 0,
+    turnsSucceeded: 0,
     toolCalls: 0,
     toolErrors: 0,
     tokensIn: 0,
@@ -225,6 +226,7 @@ export abstract class BaseOneShotSession extends EventEmitter implements ISessio
   getStats(): SessionStats & { sessionId?: string; uptime: number } {
     return {
       turns: this._stats.turns,
+      turnsSucceeded: this._stats.turnsSucceeded,
       toolCalls: this._stats.toolCalls,
       toolErrors: this._stats.toolErrors,
       tokensIn: this._stats.tokensIn,
@@ -365,8 +367,17 @@ export abstract class BaseOneShotSession extends EventEmitter implements ISessio
     return _getModelPricingBase(this.options.model, this.engineCfg.defaultModel);
   }
 
-  protected _recordTurnComplete(): void {
+  /**
+   * Call once from a subclass's close handler, with the same expression that
+   * decides the turn's `stop_reason` and whether its promise resolves.
+   *
+   * `ok` is a required parameter rather than a second method so that the outcome
+   * has one expression per engine: a turn classified as succeeded here cannot
+   * disagree with the `stop_reason` built beside it.
+   */
+  protected _recordTurnComplete(ok: boolean): void {
     this._stats.turns++;
+    if (ok) this._stats.turnsSucceeded++;
     this._stats.lastActivity = new Date().toISOString();
   }
 

--- a/src/embedded-server.ts
+++ b/src/embedded-server.ts
@@ -583,6 +583,7 @@ export class EmbeddedServer {
               cwd: s.cwd,
               created: s.created,
               turns: stats?.turns,
+              turns_succeeded: stats?.turnsSucceeded,
               tokens_in: stats?.tokensIn,
               tokens_out: stats?.tokensOut,
               cached_tokens: stats?.cachedTokens,

--- a/src/persistent-agy-session.ts
+++ b/src/persistent-agy-session.ts
@@ -277,6 +277,8 @@ export class PersistentAgySession extends BaseOneShotSession {
             this.emit(SESSION_EVENT.TEXT, r.response);
           }
           if (r.usage) turnUsage = r.usage;
+          // Only a non-SUCCESS status is recorded, and it is sticky on purpose: a later
+          // SUCCESS in the same turn must not erase a failure agy already reported.
           if (r.status && r.status !== 'SUCCESS') turnStatus = r.status;
           if (typeof r.error === 'string' && r.error.trim()) turnError = sanitizeSecrets(r.error.trim());
         }
@@ -310,7 +312,12 @@ export class PersistentAgySession extends BaseOneShotSession {
         if (settled) return;
         settled = true;
 
-        this._recordTurnComplete();
+        // One expression for the outcome: it feeds the counter here and the `stop_reason`
+        // below, and it is the reject condition at the end of this handler. The exit code
+        // stays in the conjunction — agy can report SUCCESS and then die in cleanup, and a
+        // turn whose promise rejects is not a turn that succeeded.
+        const ok = !turnError && !turnStatus && code === 0;
+        this._recordTurnComplete(ok);
 
         const text = resultText.replace(/\n$/, '');
 
@@ -336,10 +343,10 @@ export class PersistentAgySession extends BaseOneShotSession {
         const event: StreamEvent = {
           type: 'result',
           result: text,
-          // agy can exit 0 while reporting a non-SUCCESS status in the result
-          // event (e.g. a turn stopped early), so the status is authoritative
-          // when present and the exit code is the fallback.
-          stop_reason: (turnStatus ? turnStatus === 'SUCCESS' : code === 0) ? 'end_turn' : 'error',
+          // agy can exit 0 while reporting a non-SUCCESS status or an error in the
+          // result event (e.g. a turn stopped early), so the status is
+          // authoritative when present and the exit code is the fallback.
+          stop_reason: ok ? 'end_turn' : 'error',
         };
 
         this.emit(SESSION_EVENT.RESULT, event);

--- a/src/persistent-codex-app-session.ts
+++ b/src/persistent-codex-app-session.ts
@@ -137,6 +137,7 @@ export class PersistentCodexAppServerSession extends EventEmitter implements ISe
   public sessionId?: string;
   private _stats = {
     turns: 0,
+    turnsSucceeded: 0,
     toolCalls: 0,
     toolErrors: 0,
     tokensIn: 0,
@@ -483,13 +484,20 @@ export class PersistentCodexAppServerSession extends EventEmitter implements ISe
       }
       case 'turn/completed': {
         const p = params as TurnCompletedNotification;
+        // This notification can itself report how the turn ended. The engine's
+        // TurnStatus is `completed | interrupted | failed | inProgress`, so the counter
+        // tests for completion rather than for the absence of failure: an interrupted
+        // turn — which `interrupt()` on this class produces on purpose — resolves with
+        // partial text and is not a success. `stop_reason` keeps its own two-state
+        // mapping, so `interrupted` stays out of the error bucket there.
+        const failed = p.turn?.status === 'failed';
         this._stats.turns++;
+        if (p.turn?.status === 'completed') this._stats.turnsSucceeded++;
         this._stats.lastActivity = new Date().toISOString();
         // Clear the active-turn id so a later interrupt()/steer() does not target
         // an already-finished turn (only clear if it is the turn that completed).
         if (p.turn?.id && this.currentTurnId === p.turn.id) this.currentTurnId = undefined;
         const turnText = this.turnAssistantText;
-        const failed = p.turn?.status === 'failed';
         const event: StreamEvent = {
           type: 'result',
           result: turnText,
@@ -532,6 +540,7 @@ export class PersistentCodexAppServerSession extends EventEmitter implements ISe
   getStats(): SessionStats & { sessionId?: string; uptime: number; goal?: ThreadGoal | null } {
     return {
       turns: this._stats.turns,
+      turnsSucceeded: this._stats.turnsSucceeded,
       toolCalls: this._stats.toolCalls,
       toolErrors: this._stats.toolErrors,
       tokensIn: this._stats.tokensIn,

--- a/src/persistent-codex-session.ts
+++ b/src/persistent-codex-session.ts
@@ -409,7 +409,12 @@ export class PersistentCodexSession extends BaseOneShotSession {
         // Drain any final partial line as an event attempt.
         if (stdoutBuf.trim()) handleEvent(stdoutBuf);
 
-        this._recordTurnComplete();
+        // One expression for the outcome: it feeds the counter here and the
+        // `stop_reason` below. Classifying on the exit code alone reported
+        // `end_turn` for a `turn.failed` that exits 0 — the same turn the reject
+        // below has always treated as a failure.
+        const ok = !turnError && code === 0;
+        this._recordTurnComplete(ok);
 
         // Real usage from `turn.completed`. Falls back to zero rather than
         // estimated tokens — better to have an honest "0" than a guess that
@@ -438,7 +443,7 @@ export class PersistentCodexSession extends BaseOneShotSession {
         const event: StreamEvent = {
           type: 'result',
           result: assistantText,
-          stop_reason: code === 0 ? 'end_turn' : 'error',
+          stop_reason: ok ? 'end_turn' : 'error',
           session_id: this.codexThreadId,
         };
 

--- a/src/persistent-cursor-session.ts
+++ b/src/persistent-cursor-session.ts
@@ -196,7 +196,10 @@ export class PersistentCursorSession extends BaseOneShotSession {
         if (settled) return;
         settled = true;
 
-        this._recordTurnComplete();
+        // One expression for the outcome, feeding the counter here and the
+        // `stop_reason` below.
+        const ok = code === 0;
+        this._recordTurnComplete(ok);
 
         // Fallback: estimate tokens if stream events didn't provide usage
         if (!gotUsageFromEvents && resultText.value.length > 0) {
@@ -211,7 +214,7 @@ export class PersistentCursorSession extends BaseOneShotSession {
         const event: StreamEvent = {
           type: 'result',
           result: resultText.value,
-          stop_reason: code === 0 ? 'end_turn' : 'error',
+          stop_reason: ok ? 'end_turn' : 'error',
         };
 
         this.emit(SESSION_EVENT.RESULT, event);

--- a/src/persistent-custom-session.ts
+++ b/src/persistent-custom-session.ts
@@ -97,6 +97,7 @@ export class PersistentCustomSession extends EventEmitter implements ISession {
   public sessionId?: string;
   private _stats = {
     turns: 0,
+    turnsSucceeded: 0,
     toolCalls: 0,
     toolErrors: 0,
     tokensIn: 0,
@@ -539,7 +540,11 @@ export class PersistentCustomSession extends EventEmitter implements ISession {
         settled = true;
 
         const now = new Date().toISOString();
+        // One expression for the outcome, feeding the counter here and the
+        // `stop_reason` below.
+        const ok = code === 0;
         this._stats.turns++;
+        if (ok) this._stats.turnsSucceeded++;
         this._stats.lastActivity = now;
 
         if (!gotUsageFromEvents && resultText.value.length > 0) {
@@ -555,7 +560,7 @@ export class PersistentCustomSession extends EventEmitter implements ISession {
         const event: StreamEvent = {
           type: 'result',
           result: resultText.value,
-          stop_reason: code === 0 ? 'end_turn' : 'error',
+          stop_reason: ok ? 'end_turn' : 'error',
         };
 
         this.emit(SESSION_EVENT.RESULT, event);
@@ -703,6 +708,13 @@ export class PersistentCustomSession extends EventEmitter implements ISession {
           this._stats.tokensOut += usage.output_tokens || 0;
           this._stats.cachedTokens += usage.cache_read_input_tokens || 0;
           this._updateCost();
+        }
+        // The result event is the only place the outcome is known, and it arrives once
+        // per send — unlike the `user` echo that drives `turns`, which the CLI also
+        // emits per tool-result batch. `is_error` is read as truthy on purpose: for a
+        // persistent `custom` engine this event comes from an arbitrary CLI.
+        if (!(event.is_error || event.stop_reason === 'error')) {
+          this._stats.turnsSucceeded++;
         }
         this.emit(SESSION_EVENT.RESULT, event);
         this.emit(SESSION_EVENT.TURN_COMPLETE, event);
@@ -911,6 +923,7 @@ export class PersistentCustomSession extends EventEmitter implements ISession {
     const ctxWindow = this.engineConfig.contextWindow ?? 200_000;
     return {
       turns: this._stats.turns,
+      turnsSucceeded: this._stats.turnsSucceeded,
       toolCalls: this._stats.toolCalls,
       toolErrors: this._stats.toolErrors,
       tokensIn: this._stats.tokensIn,

--- a/src/persistent-gemini-session.ts
+++ b/src/persistent-gemini-session.ts
@@ -176,7 +176,11 @@ export class PersistentGeminiSession extends BaseOneShotSession {
         if (settled) return;
         settled = true;
 
-        this._recordTurnComplete();
+        // 53 is the turn limit, which resolves — a completion, not a failure. The
+        // `stop_reason` below stays three-state (it distinguishes `turn_limit`), so
+        // here `ok` only feeds the counter.
+        const ok = code === 0 || code === 53;
+        this._recordTurnComplete(ok);
 
         // Fallback: estimate tokens if stream events didn't provide usage
         if (!gotUsageFromEvents && resultText.value.length > 0) {

--- a/src/persistent-opencode-session.ts
+++ b/src/persistent-opencode-session.ts
@@ -250,7 +250,9 @@ export class PersistentOpencodeSession extends BaseOneShotSession {
         // Refuse the result rather than hand back output produced without the
         // sandbox the caller asked for.
         if (readOnlyAgentMissing) {
-          this._recordTurnComplete();
+          // Refused on purpose: it reached the engine, so it counts as a turn, but
+          // it is not a success by any reading.
+          this._recordTurnComplete(false);
           reject(
             new Error(
               "OpenCode read-only enforcement failed: the 'clawo-readonly' agent did not load, so the session " +
@@ -268,7 +270,10 @@ export class PersistentOpencodeSession extends BaseOneShotSession {
         this._stats.toolCalls += state.seenTools.size;
         this._stats.toolErrors += state.erroredTools.size;
 
-        this._recordTurnComplete();
+        // One expression for the outcome, feeding the counter here and the
+        // `stop_reason` below.
+        const ok = code === 0;
+        this._recordTurnComplete(ok);
 
         // Fallback: estimate tokens if step_finish never arrived.
         if (!state.gotUsage && finalText.length > 0) {
@@ -283,7 +288,7 @@ export class PersistentOpencodeSession extends BaseOneShotSession {
         const event: StreamEvent = {
           type: 'result',
           result: finalText,
-          stop_reason: code === 0 ? 'end_turn' : 'error',
+          stop_reason: ok ? 'end_turn' : 'error',
         };
 
         this.emit(SESSION_EVENT.RESULT, event);

--- a/src/persistent-session.ts
+++ b/src/persistent-session.ts
@@ -43,6 +43,7 @@ import {
 
 interface InternalStats {
   turns: number;
+  turnsSucceeded: number;
   toolCalls: number;
   toolErrors: number;
   tokensIn: number;
@@ -86,6 +87,7 @@ export class PersistentClaudeSession extends EventEmitter implements ISession {
     };
     this.stats = {
       turns: 0,
+      turnsSucceeded: 0,
       toolCalls: 0,
       toolErrors: 0,
       tokensIn: 0,
@@ -591,6 +593,13 @@ export class PersistentClaudeSession extends EventEmitter implements ISession {
           this.stats.cachedTokens += usage.cache_read_input_tokens || 0;
           this._updateCost();
         }
+        // The result event is the only place the outcome is known, and it arrives once
+        // per send — unlike the `user` echo that drives `turns`, which the CLI also
+        // emits per tool-result batch. `is_error` is read as truthy on purpose: for a
+        // persistent `custom` engine this event comes from an arbitrary CLI.
+        if (!(event.is_error || event.stop_reason === 'error')) {
+          this.stats.turnsSucceeded++;
+        }
         this.emit(SESSION_EVENT.RESULT, event);
         this.emit(SESSION_EVENT.TURN_COMPLETE, event);
         this._fireHook('onTurnComplete', {
@@ -765,6 +774,7 @@ export class PersistentClaudeSession extends EventEmitter implements ISession {
   getStats(): SessionStats & { sessionId?: string; uptime: number } {
     return {
       turns: this.stats.turns,
+      turnsSucceeded: this.stats.turnsSucceeded,
       toolCalls: this.stats.toolCalls,
       toolErrors: this.stats.toolErrors,
       tokensIn: this.stats.tokensIn,

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -798,6 +798,12 @@ export class SessionManager {
           // The CLI reports turn-level failures (invalid --model, auth loss) as a
           // result event with is_error and the explanation as its text — without
           // surfacing that here, the error text is indistinguishable from a reply.
+          //
+          // Deliberately NOT widened to `stop_reason === 'error'`: agy reaches this
+          // point with that stop reason while carrying a usable reply, and `error` is
+          // read as a hard failure downstream — openai-compat answers 502 and drops
+          // the reply, ultraplan discards the plan. The ledger learns the outcome from
+          // the session's own counter instead (see `_recordRunTurn`).
           const evt = (result as { event?: Record<string, unknown> }).event;
           if (evt?.is_error) {
             turnError = String((evt.result as string) || result.text || 'turn failed');
@@ -842,6 +848,7 @@ export class SessionManager {
 
   private _statsSnapshot(managed: ManagedSession): {
     turns: number;
+    turnsSucceeded: number;
     tokensIn: number;
     tokensOut: number;
     cachedTokens: number;
@@ -849,11 +856,21 @@ export class SessionManager {
     toolErrors: number;
     costUsd: number;
   } {
-    const empty = { turns: 0, tokensIn: 0, tokensOut: 0, cachedTokens: 0, toolCalls: 0, toolErrors: 0, costUsd: 0 };
+    const empty = {
+      turns: 0,
+      turnsSucceeded: 0,
+      tokensIn: 0,
+      tokensOut: 0,
+      cachedTokens: 0,
+      toolCalls: 0,
+      toolErrors: 0,
+      costUsd: 0,
+    };
     try {
       const st = managed.session.getStats();
       return {
         turns: st.turns || 0,
+        turnsSucceeded: st.turnsSucceeded || 0,
         tokensIn: st.tokensIn || 0,
         tokensOut: st.tokensOut || 0,
         cachedTokens: st.cachedTokens || 0,
@@ -897,7 +914,14 @@ export class SessionManager {
       durationMs: Date.now() - startedAt,
       toolCalls: delta(after.toolCalls, before.toolCalls),
       toolErrors: delta(after.toolErrors, before.toolErrors),
-      ok: !error,
+      // One signal, not two predicates: the row is successful when the session's own
+      // counter moved, so `ok` and `stats.turnsSucceeded` cannot disagree. `turns` is the
+      // guard — when no turn was recorded at all (a getStats() that threw and left both
+      // snapshots empty, so the counter cannot be read) this falls back to "nothing was
+      // thrown", which is what the field meant before. The counter is also what closes
+      // `stop_reason: 'process_exit'`: a CLI that dies mid-turn resolves without a result
+      // event, so the counter never moves and the row is no longer recorded as a success.
+      ok: !error && (after.turns > before.turns ? after.turnsSucceeded > before.turnsSucceeded : true),
     };
     // Fall back to the engine's own reported model, so a session started
     // without an explicit `model` still records what actually answered.
@@ -1325,6 +1349,7 @@ export class SessionManager {
       busy: boolean;
       paused: boolean;
       turns: number;
+      turnsSucceeded: number;
       costUsd: number;
       contextPercent: number;
       lastActivity: string | null;
@@ -1339,6 +1364,7 @@ export class SessionManager {
         busy: managed.session.isBusy,
         paused: managed.session.isPaused,
         turns: stats.turns,
+        turnsSucceeded: stats.turnsSucceeded,
         costUsd: stats.costUsd,
         contextPercent: stats.contextPercent,
         lastActivity: stats.lastActivity,

--- a/src/types.ts
+++ b/src/types.ts
@@ -344,7 +344,31 @@ export interface SessionConfig {
 // ─── Session Stats ───────────────────────────────────────────────────────────
 
 export interface SessionStats {
+  /**
+   * Turns that reached the engine, whatever their outcome — NOT sends, and not
+   * successes.
+   *
+   * A turn that ran and then failed still counts here; a turn refused before the
+   * engine saw it (spend cap, wrapper timeout) does not. On the one-shot engines
+   * this is one per send. On `claude` and a persistent `custom` it counts `user`
+   * events, and the CLI emits one per tool-result batch as well as the prompt echo,
+   * so a send that used eight tools counts nine — measured against claude-code
+   * stream-json, not inferred.
+   */
   turns: number;
+  /**
+   * Turns the engine reported as successful — one per send, on every engine.
+   *
+   * The predicate is the engine's own terminal verdict, not the exit code: codex
+   * fails a turn that emits `turn.failed` while exiting 0, gemini succeeds on exit
+   * 53 (its turn limit is a completion), codex-app requires `status: 'completed'`
+   * so an interrupted turn does not count.
+   *
+   * Because `turns` is not one-per-send everywhere, the difference between the two
+   * is the failure count on the one-shot engines only. On `claude` and persistent
+   * `custom`, compare `turnsSucceeded` against the number of sends instead.
+   */
+  turnsSucceeded: number;
   toolCalls: number;
   toolErrors: number;
   tokensIn: number;
@@ -355,10 +379,16 @@ export interface SessionStats {
   startTime: string | null;
   lastActivity: string | null;
   /**
-   * Approximate context window utilization (0-100).
-   * Estimated as (tokensIn + tokensOut) / 200,000 * 100.
-   * Claude Code does not expose exact context usage via the JSON protocol,
-   * so this is a best-effort heuristic that may overcount on long conversations.
+   * How full the context is (0-100). Two different readings, by engine:
+   *
+   * - one-shot engines (4.11.0) and codex (4.12.1): the last turn's prompt over
+   *   the window the engine enforces, so it rises and falls with the conversation.
+   * - `claude` and persistent `custom`: cumulative `tokensIn + tokensOut` over the
+   *   model's registry window, so it only grows and overcounts a conversation
+   *   whose history is replayed each turn. `getContextWindow()` falls back to
+   *   200,000 for a model that is not in the registry.
+   *
+   * Distinct in either case from `tokensIn`, which is total billed input tokens.
    */
   contextPercent: number;
   /** Total API retry attempts during this session */


### PR DESCRIPTION
Closes #81. Both halves, since the contradiction only closes if they land together.

Four commits: the interface, the counter across the ten sites, the ledger half, docs.

## What each engine says about its own turns

`turns` keeps every meaning it had — including the `user` echo on `claude`, which
`persistent-session.test.ts` pins. `turnsSucceeded` counts only what the engine
reported as successful, and the exit code is the wrong answer on four engines:

| engine | `ok` |
|---|---|
| `codex` | `!turnError && code === 0` |
| `agy` | `!turnError && !turnStatus && code === 0` |
| `gemini` | `code === 0 \|\| code === 53` |
| `codex-app` | `status === 'completed'` |
| `cursor` / `opencode:271` / `custom` one-shot | `code === 0` |
| `opencode:253` | `false` — refused on purpose |
| `claude`, `custom` persistent | `!(is_error \|\| stop_reason === 'error')`, in the `result` case |

Where the engine builds a `stop_reason` from the same expression, it is now the
same variable. `gemini` and `codex-app` are deliberately not: they distinguish
`turn_limit` and `interrupted`, so there the counter is the stricter of the two.

## Three things I had wrong in the issue, found by reviewing this branch before sending it

**1. `maxBudgetUsd` was never involved.** I wrote that a stale `ok: true` billed the
turn as successful work against the cap. It does not: the gate reads `costUsd`
(`session-manager.ts:740`, `:920`) and has never consulted `ok` or `error`. A
failed turn's cost counted before this PR and counts after. The defect is the
record, not the accounting. Correcting it in #81 too.

**2. `turns` is not one per send on `claude`.** In the issue I left this as an open
question — "if the CLI also emits a `user` event per tool-result batch, this is
more than once per send; I did not run it". I have now run it. It does: one `user`
event per tool-result batch on top of the prompt echo, verified against
claude-code stream-json and a real transcript. So a send that used eight tools
counts nine, and **"failures are the gap between the two counters" is true on the
one-shot engines and false on the default one.** The docs say which comparison to
make instead, and the `/v1/sessions` sample no longer carries numbers that imply
the wrong reading.

**3. "Required reaches three typed test doubles" overstated it.** `tsconfig.json`
excludes `src/__tests__` and vitest has no typecheck step, so those annotations
are never checked — two of the three already omit the required `retries`. I
updated all three so the annotation is truthful, but "required" buys nothing
there. It still buys what it was for: `tsc` enumerating the four production sites.

## The `session-manager` half is not option (c), and the difference is the point

You picked (c): widen `SendResult.error` to `stop_reason === 'error'`. I wrote it
that way first, then traced the readers.

`openai-compat.ts:919` answers **502 and drops the reply text**; `ultraplan`
(`:2513`) treats a non-empty `error` as a failed plan and discards it. agy is the
engine that reaches that path — and it gets there **carrying a usable reply**: a
non-SUCCESS status is not an empty turn. The error text would have been the
assistant's own prose, written into the durable ledger's `error` field and printed
by `clawo runs` as a failure message — unredacted, where agy's real error text
goes through `sanitizeSecrets`.

So the ledger's `ok` reads the session's counter delta instead. That gets what the
issue asked for — the ledger and `turnsSucceeded` are one number, not two
predicates kept in step by hand — without turning a turn that answered into an
HTTP error, and it closes `stop_reason: 'process_exit'` as well, which (c) did not
cover. `SendResult.error` keeps its current meaning. **If you want a caller to see
a non-success outcome, it needs its own field rather than `error`** — say the word
and I'll send that separately.

## Two bugs the review turned up, fixed here

- **`codex-app` counted an interrupted turn as a success.** Its `TurnStatus` is
  `completed | interrupted | failed | inProgress` (from the engine's own JSON
  schema, codex-cli 0.130.0) and `interrupt()` on that class produces
  `interrupted` on purpose, so `!failed` billed a cancellation as completed work.
- **`agy` can report `SUCCESS` and still exit non-zero** — it answers, then dies in
  cleanup — and that turn's promise rejects. My first version of this branch
  counted it as a success while the caller got a thrown error, which is exactly
  the contradiction this PR exists to remove. The exit code now stays in the
  conjunction, and the status is recorded sticky-on-failure so a later `SUCCESS`
  in the same turn cannot erase a failure agy already reported.

## Verification

`npm run build`, `npm run lint`, `npm run format:check`, `npm run test` — all four
green, 1013 tests.

Ten new `it` blocks and four existing tests extended. **Eight of the ten increment
sites were mutation-tested** — restore the old expression, confirm a test goes red
— in nine mutations (agy twice; its assignment and its predicate fail
independently). The two exceptions are both `custom`: the suite has no test file
for that engine in either mode. I am not claiming coverage there.

That distinction is worth stating because I got it wrong first: the earlier
version of this branch cited "the full agy suite passes with the old assignment
restored" as evidence of no behaviour change. It was evidence of no coverage — the
suite had no case with a status *and* a non-zero exit, which is precisely the bug.

## Unrelated, but you should know

`src/__tests__/embedded-server.test.ts` fails intermittently with
`write ECONNRESET` — 1 run in 6 in isolation, on files this PR does not touch. It
turns CI red at random. Happy to file it separately.

## Beyond the mandate — say the word and I drop either

`turns_succeeded` on `/v1/sessions` (`embedded-server.ts`) and in
`health().details`: those are the two places that published `turns` with no way to
qualify it, and `/v1/sessions` is the consumer that made me open the issue.
`bin/cli.ts` still prints `turns` alone; I left it, since that is a UX call.

Docs per CONTRIBUTING: `sessions.md`, `multi-engine.md`, `observability.md`,
`openai-compat.md`.
