### PR TITLE
fix(openai-compat): send tool results the engine has not seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **OpenAI-compat: tool results were discarded on any thread the engine had not
+  opened.** `extractUserMessage()` decided whether to send the caller's tool
+  results by reading the SHAPE of the messages array — "is the last non-system
+  message a `tool` role?" — to answer a question about the ENGINE's state: "does
+  its transcript already hold them?". The two come apart whenever there is no
+  transcript. A `[..., tool, user]` or `[..., tool, assistant]` array sent to a
+  session whose native conversation did not exist yet had every result dropped,
+  and the turn was answered without them while the request still returned
+  200. The decision is now `serializeToolResults()`'s alone, keyed on
+  `threadHasHistory` — the parameter that already described the engine. Requests
+  carrying no tool results are untouched.
+
+  The `latestRoundOnly` scoping is unchanged, and so is the condition it rests
+  on, now asserted rather than assumed: it slices from the array's last
+  `assistant` message, so it bounds a tool loop to one round per hop only for a
+  client that echoes the `tool_calls` turn it is answering. An array with no
+  `assistant` message anywhere gives `lastIndexOf()` `-1` and `slice(0)` — the
+  whole array — so on that array `latestRoundOnly` is a no-op: the serialized
+  block is byte-identical with the flag set and unset, and the client re-sends the
+  entire loop on every hop, before this change as after it. Same for a turn with
+  no live conversation, where nothing is scoped by design. So "the duplication is
+  bounded to one round" holds only where the scoping actually runs.
+  `skills/references/openai-compat.md` documents each case.
+
+- **Docs: `X-Session-Reset` is not honored on a request that ends in a `tool`
+  result.** No behaviour change here — the header is parsed after the branch that
+  handles a trailing `tool` role returns, so on that one shape the reset stops no
+  session and creates no conversation, and the turn is treated as a resumed one.
+  `skills/references/openai-compat.md` said a reset turn always stops the session
+  and starts a new one; it now carries the exception.
+
 ## [6.0.1] - 2026-08-24
 
 ### Fixed

--- a/skills/references/openai-compat.md
+++ b/skills/references/openai-compat.md
@@ -108,11 +108,84 @@ and opencode's session id), not merely that the session is in the manager's map:
 first turn that died before announcing one leaves a session behind that resumes
 nothing, and those turns keep receiving the full prompt.
 
+One exception to the sentence above, and it is a defect rather than a design: on a
+request whose last non-system message is a `tool` result, `X-Session-Reset` is not
+seen at all. The header is parsed after the branch that handles a trailing `tool`
+role returns, so on that shape the reset stops nothing, creates nothing, and the
+turn is treated as a resumed one — the prompt is skipped if the thread is live.
+Every other shape, `[..., tool, user]` included, honors it. A client that needs a
+reset mid-tool-loop has to send it on a turn that does not end in a `tool`
+message.
+
 `OPENAI_COMPAT_TOOLS_PER_MESSAGE=1` opts out: it re-sends the full block on every
 turn for `claude` too, which is what makes a changing tool set work inside one
 session (in that mode the tool list is deliberately left out of the session hash).
 It costs the per-turn growth described above — only use it if the tool set really
 does change mid-conversation.
+
+## Tool results on the way back
+
+A `tool` role message in the caller's array is the result of a call the model asked for on an
+earlier turn. The `tool` messages that are in scope are serialized into one `<tool_results>` block
+and prepended to the caller's latest `user` text in the message the CLI receives.
+
+What is in scope depends on what the engine is holding, not on where the `tool` messages sit in the
+array:
+
+| On this turn the engine                                                                                                                   | What is sent                                                                                                            |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| is **not** resuming a conversation — no session yet, a session that never announced a conversation id, or one being stopped and recreated | every `tool` message in the array                                                                                       |
+| **is** resuming a live conversation                                                                                                       | only the `tool` messages after the array's last `assistant` message — everything before it is already in the transcript |
+
+Whether the engine is resuming is resolved with the same `nativeThreadIsLive()` check as the
+middle row of [Tool definitions](#tool-definitions-and-where-they-live). Engines with no resume
+surface (`gemini`, one-shot `custom`) are never in the second row, because
+`engineHasNativeConversation()` gates the check.
+
+Two engines reach the second row from map presence alone rather than from a captured id, because
+`nativeThreadIsLive()` has no case for them and its `default` arm returns `true`: `claude`, which
+holds its context in a live process and has no separate id to check, and `grok` — which does resume
+by id (`--resume <sessionUUID>`), but whose id is absent from `SessionStats`, so there is nothing to
+check even though there is something to check for. A `grok` session whose first turn died before
+emitting its id therefore reports a live thread and gets its earlier rounds scoped away. That is
+pre-existing and not addressed here; fixing it means adding the field.
+
+The trailing role of the array does not enter into it — `[..., tool]`, `[..., tool, user]` and
+`[..., tool, assistant]` are read the same way, and the caller's latest `user` text, when there is
+one, is appended after the block either way. A turn whose latest `user` message carries no text at
+all — a multimodal content array holding only an image — gets the block as the whole message. An
+array carrying no `tool` message at all is untouched: no block, no wrapper, the message goes as it
+came.
+
+The third case in the first row — a session being stopped and recreated — is `X-Session-Reset`, and
+it puts the turn in that row on every shape where the header is read at all. That excludes an array
+ending in a `tool` result, where the header is not seen; see the note under [Tool definitions](#tool-definitions-and-where-they-live).
+
+### What the scoping is for, and what it does not cover
+
+On a resumed conversation the scoping is what keeps a tool loop linear instead of quadratic. With a
+30k-character batch per round, the tenth hop carries ~30k characters of results instead of the
+~300k the engine has already seen. Two properties are worth checking against your own client before
+relying on it:
+
+- **The boundary is the last `assistant` message, and what matters is whether one sits AFTER the
+  earliest unsent `tool` message** — not whether the array contains one at all. The OpenAI wire
+  format has the caller echo the `assistant` turn that carried the `tool_calls` ahead of the
+  matching `tool` messages, and a client that echoes it pays for one round per hop. When no
+  `assistant` message follows the earliest unsent result, `lastIndexOf('assistant')` is behind them
+  all and the slice keeps everything, so the scoping is a no-op. Two shapes land there: an array
+  with no `assistant` message at all, and one `assistant` announcing N parallel calls followed by
+  its N results — the second is a no-op that costs nothing, since those N results _are_ one round.
+- **A round can go out twice.** Engine replies are not read back out of the array, so a round the
+  caller did not record an `assistant` turn for looks the same as a round the engine never saw, and
+  it goes out again. The duplication is bounded to one round wherever the scoping runs — i.e. on a
+  resumed conversation whose array does carry an `assistant` message. It is unbounded in the two
+  cases where nothing is scoped: the row above, and any turn in the first row of the table (no
+  resumed conversation), where the whole array goes out by design because the engine holds none of
+  it.
+
+Neither applies to a caller that keeps its own transcript and forwards only the latest turn — it
+sends one round at a time.
 
 ## Environment variables
 

--- a/src/__tests__/openai-compat.test.ts
+++ b/src/__tests__/openai-compat.test.ts
@@ -759,20 +759,60 @@ describe('extractUserMessage with tool results', () => {
     expect(result.isNewConversation).toBe(false);
   });
 
-  it('returns only user message when last message is user (tool results already in CLI history)', () => {
-    const messages: OpenAIChatMessage[] = [
+  // This case used to be one test asserting the results are never sent when the array ends in a
+  // user message, titled "(tool results already in CLI history)" — but it called
+  // extractUserMessage(messages) with no third argument, i.e. threadHasHistory = false, which is
+  // the function's way of being told the engine has NO history. The title named a precondition the
+  // body never set, and the assertion held only because the code was reading the shape of the
+  // array instead of the state of the thread. Split into the two cases the title implies.
+  const searchThenFollowUp: OpenAIChatMessage[] = [
+    { role: 'user', content: 'Search for news' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'search', arguments: '{}' } }],
+    },
+    { role: 'tool', content: 'News results here', tool_call_id: 'call_1' },
+    { role: 'user', content: 'Summarize the results' },
+  ];
+
+  it('drops the results that the CLI history really does hold', () => {
+    // The title's original claim, now actually exercised: a thread that is live AND has taken a
+    // turn since round one. ROUND-ONE is in the transcript, so it is not re-sent; ROUND-TWO landed
+    // after the engine's last assistant turn, so it is.
+    const twoRounds: OpenAIChatMessage[] = [
       { role: 'user', content: 'Search for news' },
       {
         role: 'assistant',
         content: null,
         tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'search', arguments: '{}' } }],
       },
-      { role: 'tool', content: 'News results here', tool_call_id: 'call_1' },
+      { role: 'tool', content: 'ROUND-ONE', tool_call_id: 'call_1' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'call_2', type: 'function', function: { name: 'search', arguments: '{}' } }],
+      },
+      { role: 'tool', content: 'ROUND-TWO', tool_call_id: 'call_2' },
       { role: 'user', content: 'Summarize the results' },
     ];
-    const result = extractUserMessage(messages);
-    expect(result.userMessage).toBe('Summarize the results');
-    expect(result.userMessage).not.toContain('<tool_results>');
+    const result = extractUserMessage(twoRounds, {}, true);
+    expect(result.userMessage).not.toContain('ROUND-ONE');
+    expect(result.userMessage).toContain('ROUND-TWO');
+    expect(result.userMessage).toContain('Summarize the results');
+  });
+
+  it('sends the results when there is no CLI history to hold them', () => {
+    // Same array as the original test, same default third argument. On the deployment where this
+    // was found, every discard on the revisions that log session state — 337 of those 337 rows, out
+    // of 725 discards in total; the other 388 predate the fields — was exactly this shape of
+    // thread: no session, engine turn count 0, so the CLI could not have been holding them. The
+    // old assertion here is what made the discard look intended.
+    const result = extractUserMessage(searchThenFollowUp);
+    expect(result.userMessage).toContain('<tool_results>');
+    expect(result.userMessage).toContain('News results here');
+    expect(result.userMessage).toContain('Summarize the results');
+    expect(result.isNewConversation).toBe(false);
   });
 });
 
@@ -902,6 +942,349 @@ describe('serializeToolResults — latestRoundOnly', () => {
   });
 });
 
+// ─── extractUserMessage — tool results vs. what the engine has actually seen ──
+//
+// The bug: the decision to send tool results was keyed on the SHAPE of the caller's array (is the
+// last non-system message a tool role?) to answer a question about the ENGINE's state (does its
+// transcript already hold them?). Those come apart on any thread with no history, and there the
+// results were dropped while the request still returned 200.
+//
+// Measured on one deployment — a codex-engine gateway — across every row the log field has, and
+// with OUR OWN verification, smoke, probe and load-test sessions removed (that includes the two
+// runs on 2026-08-04 that produced the field's first rows): 8,451 requests carried tool results,
+// and on 725 of them (8.6%) every result was discarded — 45,873,844 characters of the 445,349,211
+// carried. Trailing role on the discards: 420 `user`, 305 `assistant`, which is why both shapes
+// are covered below.
+//
+// Read those with their denominators, because the traffic is concentrated. 10 of the 12 agents
+// that ever sent tool results hit it — 83%, and 12 is the whole set of agents that sent any, so
+// there is no larger denominator to divide by. One agent accounts for 74.8% of the discarded
+// characters, and one half-hourly cron re-sending one of two payloads accounts for 272 of the 725
+// discards (37.5%) while being only 7.5% of the characters. Dropping that cron still leaves 453
+// discards across 10 agents on 17 days. It is not one repeating payload either way: the heaviest
+// agent's 328 discards carry 193 distinct payload sizes.
+//
+// Restricting the same data to the 18 complete UTC days 2026-08-05..2026-08-22 gives 8,377 / 715 /
+// 44,672,264 characters / 418 `user` + 297 `assistant` — so nothing here rests on the window.
+//
+// The number that does not move with the denominator: on 720 of the 725 the engine had no live
+// conversation to hold the results — the gateway logs the same nativeThreadIsLive predicate this
+// fix keys on — and on the 337 discards from the revisions that also log session state, 337 of 337
+// had no session at all and a turn count of 0, against 48 of 2,905 for the results that were
+// DELIVERED on those same revisions.
+
+describe('extractUserMessage — tool results vs. thread history', () => {
+  let savedEnv: string | undefined;
+  beforeEach(() => {
+    savedEnv = process.env.OPENAI_COMPAT_NEW_CONVO_HEURISTIC;
+    delete process.env.OPENAI_COMPAT_NEW_CONVO_HEURISTIC;
+  });
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.OPENAI_COMPAT_NEW_CONVO_HEURISTIC;
+    else process.env.OPENAI_COMPAT_NEW_CONVO_HEURISTIC = savedEnv;
+  });
+
+  const call = (id: string): OpenAIChatMessage => ({
+    role: 'assistant',
+    content: null,
+    tool_calls: [{ id, type: 'function', function: { name: 'search', arguments: '{}' } }],
+  });
+
+  const oneRound: OpenAIChatMessage[] = [
+    { role: 'system', content: 'sys' },
+    { role: 'user', content: 'go' },
+    call('c1'),
+    { role: 'tool', tool_call_id: 'c1', content: 'RESULT-ONE' },
+  ];
+  const twoRounds: OpenAIChatMessage[] = [
+    ...oneRound,
+    call('c2'),
+    { role: 'tool', tool_call_id: 'c2', content: 'RESULT-TWO' },
+  ];
+
+  // ── the 420 of 725 measured discards that ended in `user` ──────────────────
+  it('sends the results when a trailing user message arrives on a thread with no history', () => {
+    const result = extractUserMessage([...oneRound, { role: 'user', content: 'follow up' }], {}, false);
+    expect(result.userMessage).toContain('RESULT-ONE');
+    expect(result.userMessage).toContain('follow up');
+    expect(result.isNewConversation).toBe(false);
+  });
+
+  // ── order is chronology, not cosmetics: the results answer the assistant's earlier `tool_calls`,
+  //    the caller's text is what came after. Reversed, the engine reads an instruction followed by
+  //    a wall of output with nothing saying what asked for it. Asserted on the offsets because
+  //    `toContain` twice passes either way.
+  it("puts the results before the caller's new text, not after", () => {
+    const result = extractUserMessage([...oneRound, { role: 'user', content: 'follow up' }], {}, false);
+    // Both offsets asserted non-negative FIRST. Comparing them alone is vacuous on any build that
+    // drops the block: indexOf returns -1, and -1 < 0 passes. That is exactly the behaviour this
+    // file exists to refute, so the ordering assertion has to be guarded by presence.
+    expect(result.userMessage.indexOf('RESULT-ONE')).toBeGreaterThanOrEqual(0);
+    expect(result.userMessage.indexOf('follow up')).toBeGreaterThanOrEqual(0);
+    expect(result.userMessage.indexOf('RESULT-ONE')).toBeLessThan(result.userMessage.indexOf('follow up'));
+  });
+
+  // ── every other assertion in this file on a block-carrying message is `toContain`, which cannot
+  //    see the separator, the framing sentence, or a truncated payload. One exact-string assertion
+  //    pins the whole assembled message so those stay pinned too.
+  it('assembles exactly this message, separator and framing included', () => {
+    // Its own fixture, with a payload deliberately longer than any plausible truncation constant:
+    // every other tool payload in this file is under 20 characters, so a `.slice(0, 20)` on the
+    // serializer passes an exact-string assertion built on those.
+    const longPayload = 'Q3 revenue was 4.2M, up 18% year over year, across 11 regions.';
+    const result = extractUserMessage(
+      [
+        { role: 'user', content: 'go' },
+        call('c1'),
+        { role: 'tool', tool_call_id: 'c1', content: longPayload },
+        { role: 'user', content: 'follow up' },
+      ],
+      {},
+      false,
+    );
+    expect(result.userMessage).toBe(
+      `<tool_results>\n<tool_result tool_call_id="c1">\n${longPayload}\n</tool_result>\n</tool_results>\n\n` +
+        'Above are the results of the tool calls you requested. Continue your response based on these results.\n\n' +
+        'follow up',
+    );
+  });
+
+  // ── the docstring this PR edited says the parameter "defaults to false so any caller that cannot
+  //    establish that keeps the safe behaviour of sending every result". Every existing default-arg
+  //    call site carries a one-round array, where scoping is unobservable — so the documented
+  //    default was asserted nowhere. Two rounds make it observable.
+  it('defaults to sending everything when the caller omits the parameter', () => {
+    const result = extractUserMessage([...twoRounds, { role: 'user', content: 'follow up' }]);
+    expect(result.userMessage).toContain('RESULT-ONE');
+    expect(result.userMessage).toContain('RESULT-TWO');
+  });
+
+  // ── the legacy webchat heuristic returns from its own branch, and it is the branch these clients
+  //    take: ChatGPT-Next-Web / Open WebUI re-send the whole transcript every turn, so a trailing
+  //    `user` turn behind tool results is their normal shape, not an edge case. Reverting just that
+  //    return to `lastUserText` restores the bug for all of them and left this file green.
+  it('delivers the results on the legacy-heuristic path too', () => {
+    const prev = process.env.OPENAI_COMPAT_NEW_CONVO_HEURISTIC;
+    process.env.OPENAI_COMPAT_NEW_CONVO_HEURISTIC = '1';
+    try {
+      const result = extractUserMessage([...oneRound, { role: 'user', content: 'follow up' }], {}, false);
+      expect(result.userMessage).toContain('RESULT-ONE');
+      expect(result.userMessage).toContain('follow up');
+      expect(result.isNewConversation).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.OPENAI_COMPAT_NEW_CONVO_HEURISTIC;
+      else process.env.OPENAI_COMPAT_NEW_CONVO_HEURISTIC = prev;
+    }
+  });
+
+  // ── the 305 of 725 that ended in `assistant`. If the fix does not cover this shape it describes
+  //    the bug wrongly: the trailing role was never what decided anything.
+  it('sends the results when a trailing assistant message arrives on a thread with no history', () => {
+    const result = extractUserMessage([...oneRound, { role: 'assistant', content: 'partial' }], {}, false);
+    expect(result.userMessage).toContain('RESULT-ONE');
+    expect(result.isNewConversation).toBe(false);
+  });
+
+  // ── the same trailing-user shape on a LIVE thread. The engine got no turn between the tool
+  //    result and the caller appending a user message, so it has not seen the latest round — but it
+  //    HAS seen everything before its own last assistant turn. Both halves are asserted, because
+  //    only asserting the first would let a fix pass that re-sends the whole loop.
+  it('sends only the unseen round when a trailing user message arrives on a live thread', () => {
+    const result = extractUserMessage([...twoRounds, { role: 'user', content: 'follow up' }], {}, true);
+    expect(result.userMessage).not.toContain('RESULT-ONE');
+    expect(result.userMessage).toContain('RESULT-TWO');
+    expect(result.userMessage).toContain('follow up');
+  });
+
+  // ── documented, not fixed: on a LIVE thread a trailing assistant message is the engine's own
+  //    turn, which it could only have produced with those results in hand, so there is nothing new
+  //    to send. Pinned here so the day someone needs the other answer, they see this test first.
+  it('sends nothing when a live thread already answered past the results', () => {
+    const result = extractUserMessage([...oneRound, { role: 'assistant', content: 'partial' }], {}, true);
+    expect(result.userMessage).not.toContain('<tool_results>');
+    expect(result.userMessage).toBe('go');
+  });
+
+  // ── a reset means the engine is about to be handed a brand new thread, so on that turn it holds
+  //    nothing and every result has to go out. Scoping against the thread the caller just asked to
+  //    discard would be the same drop with extra steps.
+  it('still honors a reset header on a trailing user message carrying tool results', () => {
+    const result = extractUserMessage(
+      [...twoRounds, { role: 'user', content: 'fresh' }],
+      { 'x-session-reset': 'TRUE' },
+      true,
+    );
+    expect(result.isNewConversation).toBe(true);
+    expect(result.userMessage).toContain('RESULT-ONE');
+    expect(result.userMessage).toContain('RESULT-TWO');
+  });
+
+  // ── the regression this replaces must NOT come back. The guard's provenance is v2.11.1, dated
+  //    2026-04-11 in this CHANGELOG (2.11.0, the day before, is the release that ADDED tool support;
+  //    it is 2.11.1 that narrowed serialization to a trailing `tool` role): "tool results processed
+  //    even when last message is not tool role — preventing stale tool results from being
+  //    re-injected on user follow-ups". Pre-4.x commits are not in this repo, so that entry is the
+  //    provenance. The shape test was the only signal available then; the scoping added since
+  //    is a stronger one. On a live thread the exact v2.11.1 shape — engine answered, user follows
+  //    up — still sends nothing, because everything before the engine's own assistant turn is
+  //    scoped away. With no thread there is no transcript to be stale, so the result goes out.
+  it('does not re-inject stale results into a live thread that already answered', () => {
+    const answeredThenFollowUp: OpenAIChatMessage[] = [
+      { role: 'user', content: 'go' },
+      call('c1'),
+      { role: 'tool', tool_call_id: 'c1', content: 'STALE' },
+      { role: 'assistant', content: 'here is the answer' },
+      { role: 'user', content: 'follow up' },
+    ];
+    expect(extractUserMessage(answeredThenFollowUp, {}, true).userMessage).toBe('follow up');
+    expect(extractUserMessage(answeredThenFollowUp, {}, false).userMessage).toContain('STALE');
+  });
+
+  // ── the blocker. The empty-block guard on the line that assembles userMessage is what keeps a
+  //    plain conversation out of the tool path. Replacing it with an unconditional prepend — the
+  //    obvious simplification — fails 8 tests in this file, 3 of which exist on main already
+  //    ('extracts last user message', 'extracts system prompt without flagging it as a new
+  //    conversation', 'does NOT treat a single user message as a new conversation without reset
+  //    header'), because every message then arrives with a leading blank line. Measured, not
+  //    assumed. Asserting the negative shape here so it cannot come back quietly.
+  it('leaves a request with no tool results untouched', () => {
+    const plain: OpenAIChatMessage[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'a' },
+      { role: 'assistant', content: 'b' },
+      { role: 'user', content: 'c' },
+    ];
+    for (const live of [false, true]) {
+      const result = extractUserMessage(plain, {}, live);
+      expect(result.userMessage).toBe('c');
+      expect(result.userMessage).not.toContain('<tool_results>');
+      expect(result.systemPrompt).toBe('sys');
+      expect(result.isNewConversation).toBe(false);
+    }
+  });
+
+  // ── the OTHER half of that assembly line, and the one with no test until now. The expression is
+  //    `toolResultBlock && lastUserText ? join : toolResultBlock || lastUserText`. Deleting the
+  //    `toolResultBlock ||` term leaves `: lastUserText`, which type-checks, keeps every other test
+  //    in this file green, and silently reproduces THE BUG THIS PR FIXES — the results vanish —
+  //    on any turn where the caller's latest `user` message carries no text. That is a real OpenAI
+  //    shape, not a contrivance: a multimodal turn whose content array holds only an image part.
+  //    textOf() joins the `text` fields, so it returns '', and the block is then the entire
+  //    message. Measured: with the fallback the message is 191 characters and carries the result;
+  //    with `: lastUserText` it is ''.
+  it('sends the results when the latest user turn carries an image and no text', () => {
+    const imageOnly: OpenAIChatMessage[] = [
+      { role: 'user', content: [{ type: 'image_url' }] },
+      call('c1'),
+      { role: 'tool', tool_call_id: 'c1', content: 'RESULT-ONE' },
+      // A non-`tool` trailing role, or the early return above would handle it instead.
+      { role: 'assistant', content: 'let me look at that' },
+    ];
+    const result = extractUserMessage(imageOnly, {}, false);
+    expect(result.userMessage).toContain('<tool_results>');
+    expect(result.userMessage).toContain('RESULT-ONE');
+    // No stray separator: the block is the whole message, not appended to an empty string.
+    expect(result.userMessage.startsWith('<tool_results>')).toBe(true);
+    expect(result.userMessage.endsWith('\n')).toBe(false);
+  });
+
+  it('leaves the active tool-use cycle exactly as it was', () => {
+    // Unchanged on both sides of threadHasHistory: this shape always took the tool path.
+    expect(extractUserMessage(twoRounds, {}, false).userMessage).toContain('RESULT-ONE');
+    expect(extractUserMessage(twoRounds, {}, true).userMessage).not.toContain('RESULT-ONE');
+    expect(extractUserMessage(twoRounds, {}, true).userMessage).toContain('RESULT-TWO');
+  });
+
+  // ── the legacy heuristic keeps firing exactly where it fired before. Folding it into a single
+  //    early isNewConversation decision reads cleaner but flips this case from "deliver the
+  //    results" to "recycle the session first", which is a behaviour change for legacy clients
+  //    that this fix has no business making.
+  it('does not let the legacy heuristic newly fire on a lone tool result', () => {
+    process.env.OPENAI_COMPAT_NEW_CONVO_HEURISTIC = '1';
+    const lone: OpenAIChatMessage[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'tool', tool_call_id: 'c1', content: 'RESULT-ONE' },
+    ];
+    for (const live of [false, true]) {
+      const result = extractUserMessage(lone, {}, live);
+      expect(result.isNewConversation).toBe(false);
+      expect(result.userMessage).toContain('RESULT-ONE');
+    }
+    // And it still fires where it always did.
+    expect(
+      extractUserMessage([
+        { role: 'system', content: 'sys' },
+        { role: 'user', content: 'first' },
+      ]).isNewConversation,
+    ).toBe(true);
+  });
+
+  // ── the 400 contract is unchanged. Both the "no user message anywhere" reject and the carve-out
+  //    that lets the active cycle through without one.
+  it('keeps rejecting an array with no user message', () => {
+    expect(() =>
+      extractUserMessage(
+        [
+          { role: 'system', content: 'sys' },
+          { role: 'tool', tool_call_id: 'c1', content: 'RESULT-ONE' },
+          { role: 'assistant', content: 'x' },
+        ],
+        {},
+        false,
+      ),
+    ).toThrow('No user message');
+  });
+
+  it('keeps accepting the active cycle with no user message', () => {
+    const result = extractUserMessage(
+      [{ role: 'system', content: 'sys' }, call('c1'), { role: 'tool', tool_call_id: 'c1', content: 'RESULT-ONE' }],
+      {},
+      false,
+    );
+    expect(result.userMessage).toContain('RESULT-ONE');
+  });
+
+  // ── serializeToolResults is untouched, and its quadratic guard has to stay that way. 10 rounds
+  //    of 30k: a live thread pays for one round on BOTH shapes the fix now routes through it, so
+  //    closing the trailing-user case costs a round, not the whole loop.
+  it('keeps the tool loop linear on a live thread at 10 rounds x 30k', () => {
+    const batch = 'X'.repeat(30000);
+    const loop10: OpenAIChatMessage[] = [{ role: 'user', content: 'go' }];
+    for (let i = 1; i <= 10; i++) {
+      loop10.push(call('c' + i));
+      loop10.push({ role: 'tool', tool_call_id: 'c' + i, content: batch });
+    }
+    const countRounds = (s: string) => (s.match(/<tool_result /g) || []).length;
+
+    // active cycle, live thread: one round (this is upstream behaviour, asserted here so the fix
+    // cannot regress it)
+    expect(countRounds(extractUserMessage(loop10, {}, true).userMessage)).toBe(1);
+    // trailing user message, live thread: also one round — the case the fix opens
+    const withFollowUp: OpenAIChatMessage[] = [...loop10, { role: 'user', content: 'follow up' }];
+    expect(countRounds(extractUserMessage(withFollowUp, {}, true).userMessage)).toBe(1);
+    expect(extractUserMessage(withFollowUp, {}, true).userMessage.length).toBeLessThan(31000);
+    // no history: all ten, which is the only correct answer and is one request per session
+    expect(countRounds(extractUserMessage(withFollowUp, {}, false).userMessage)).toBe(10);
+  });
+
+  // ── and the limit of that guarantee, pinned because CHANGELOG.md now states it. The scoping
+  //    slices from the LAST `assistant` message, so an array carrying none at all — a client that
+  //    does not echo the `tool_calls` turn it is answering — gets lastIndexOf() === -1, slice(0),
+  //    and every round. Unchanged by this fix, and true on the active-cycle shape too; the fix
+  //    only makes the trailing-user shape reach the same code.
+  it('does not scope at all when the array carries no assistant message', () => {
+    const noAssistant: OpenAIChatMessage[] = [
+      { role: 'user', content: 'go' },
+      { role: 'tool', tool_call_id: 'c1', content: 'RESULT-ONE' },
+      { role: 'tool', tool_call_id: 'c2', content: 'RESULT-TWO' },
+    ];
+    expect(serializeToolResults(noAssistant, true)).toContain('RESULT-ONE');
+    const live = extractUserMessage([...noAssistant, { role: 'user', content: 'follow up' }], {}, true);
+    expect(live.userMessage).toContain('RESULT-ONE');
+    expect(live.userMessage).toContain('RESULT-TWO');
+  });
+});
+
 // ─── handleChatCompletion ────────────────────────────────────────────────────
 //
 // This handler had no unit coverage, which is how a regression reached two
@@ -917,7 +1300,7 @@ describe('serializeToolResults — latestRoundOnly', () => {
  * `startSession()` clears the captured id (a new conversation has none yet) and
  * `stopSession()` drops the session, so the create/dispose flow is real.
  */
-function fakeManager(opts: { threadId?: string; engineIdKey?: string } = {}) {
+function fakeManager(opts: { threadId?: string; engineIdKey?: string; throwOnStatus?: boolean } = {}) {
   const idKey = opts.engineIdKey ?? 'codexThreadId';
   const live = new Map<string, Record<string, string | undefined>>();
   const sent: string[] = [];
@@ -940,9 +1323,12 @@ function fakeManager(opts: { threadId?: string; engineIdKey?: string } = {}) {
       live.delete(name);
     },
     listSessions: () => [...live.keys()].map((name) => ({ name })),
-    getStatus: (name: string) => ({
-      stats: { tokensIn: 0, tokensOut: 0, contextPercent: 1, ...(live.get(name) ?? {}) },
-    }),
+    getStatus: (name: string) => {
+      // The real manager throws for a session it does not know, or one that died between the
+      // listSessions() call and this one. A total double makes the handler's catch unreachable.
+      if (opts.throwOnStatus) throw new Error('session is gone');
+      return { stats: { tokensIn: 0, tokensOut: 0, contextPercent: 1, ...(live.get(name) ?? {}) } };
+    },
     compactSession: async () => ({}),
   };
   return { manager, sent };
@@ -1010,5 +1396,248 @@ describe('handleChatCompletion — system prompt across a reset', () => {
       fakeRes(),
     );
     expect(sent[0]).not.toContain(ANCHOR);
+  });
+});
+
+// ─── handleChatCompletion — the wiring, not the predicate ────────────────────
+//
+// Everything above calls extractUserMessage() with `threadHasHistory` written out by hand, which
+// tests the decision and NOT the wiring that feeds it. A fix whose handler passed the wrong value —
+// or a literal — would leave every one of those tests green while production still dropped the
+// results. So these drive the real handler with a SessionManager double and never mention
+// `threadHasHistory`: the handler has to derive it from `listSessions()` + `getStatus()`.
+//
+// The shapes are the measured ones. `[user, assistant(tool_calls), tool, user]` with no session is
+// what all 337 discards that logged session state looked like: needs_create=yes, engine turn count
+// 0. Two of these tests carry TWO rounds rather than one, because with a single round the scoping
+// has nothing to remove — `slice(lastIndexOf('assistant') + 1)` keeps the trailing tool message
+// either way — so a one-round array cannot tell a correct `false` apart from a hardcoded `true`.
+describe('handleChatCompletion — tool results reach the engine that has not seen them', () => {
+  const call = (id: string) => ({
+    role: 'assistant' as const,
+    content: null,
+    tool_calls: [{ id, type: 'function' as const, function: { name: 'search', arguments: '{}' } }],
+  });
+
+  // The exact production shape: one round, then the caller's next user turn.
+  const oneRoundThenUser = [
+    { role: 'user', content: 'search for the Q3 numbers' },
+    call('c1'),
+    { role: 'tool', tool_call_id: 'c1', content: 'ROUND-ONE-PAYLOAD' },
+    { role: 'user', content: 'now summarize' },
+  ];
+
+  // Two rounds, then the caller's next user turn. On a live thread ROUND-ONE is behind the last
+  // `assistant` message and ROUND-TWO is in front of it, so the two values of `threadHasHistory`
+  // give observably different messages — which is what makes this shape able to fail.
+  const twoRoundsThenUser = [
+    { role: 'user', content: 'search for the Q3 numbers' },
+    call('c1'),
+    { role: 'tool', tool_call_id: 'c1', content: 'ROUND-ONE-PAYLOAD' },
+    call('c2'),
+    { role: 'tool', tool_call_id: 'c2', content: 'ROUND-TWO-PAYLOAD' },
+    { role: 'user', content: 'now summarize' },
+  ];
+
+  it('sends the results when the session does not exist yet', async () => {
+    // `fresh` is absent from listSessions(), so the handler must resolve threadHasHistory to false
+    // on its own. fakeManager is handed a thread id precisely so that a handler that looked the id
+    // up on the wrong session, or ignored `sessionExists`, would see a live thread and scope.
+    const { manager, sent } = fakeManager({ threadId: 'thread_abc' });
+    await handleChatCompletion(
+      manager,
+      { model: 'gpt-5.5', messages: oneRoundThenUser },
+      { 'x-session-id': 'fresh' },
+      fakeRes(),
+    );
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain('ROUND-ONE-PAYLOAD');
+    expect(sent[0]).toContain('now summarize');
+  });
+
+  it('sends BOTH rounds when the session does not exist yet', async () => {
+    const { manager, sent } = fakeManager({ threadId: 'thread_abc' });
+    await handleChatCompletion(
+      manager,
+      { model: 'gpt-5.5', messages: twoRoundsThenUser },
+      { 'x-session-id': 'fresh' },
+      fakeRes(),
+    );
+    expect(sent[0]).toContain('ROUND-ONE-PAYLOAD');
+    expect(sent[0]).toContain('ROUND-TWO-PAYLOAD');
+  });
+
+  it('sends both rounds when the session exists but the engine never announced a conversation', async () => {
+    // The other way the handler reaches false: the session is in the map, but codex never emitted
+    // `thread.started`, so there is no transcript to have held anything.
+    const { manager, sent } = fakeManager({ threadId: undefined });
+    await handleChatCompletion(
+      manager,
+      { model: 'gpt-5.5', messages: twoRoundsThenUser },
+      { 'x-session-id': 'demo' },
+      fakeRes(),
+    );
+    expect(sent[0]).toContain('ROUND-ONE-PAYLOAD');
+    expect(sent[0]).toContain('ROUND-TWO-PAYLOAD');
+  });
+
+  it('scopes away the round a live thread already holds', async () => {
+    // The regression guard on the other side. A handler that passed a literal false — or dropped
+    // the nativeThreadIsLive() lookup — would re-send ROUND-ONE on every hop of the loop.
+    const { manager, sent } = fakeManager({ threadId: 'thread_abc' });
+    await handleChatCompletion(
+      manager,
+      { model: 'gpt-5.5', messages: twoRoundsThenUser },
+      { 'x-session-id': 'demo' },
+      fakeRes(),
+    );
+    expect(sent[0]).not.toContain('ROUND-ONE-PAYLOAD');
+    expect(sent[0]).toContain('ROUND-TWO-PAYLOAD');
+    expect(sent[0]).toContain('now summarize');
+  });
+
+  it('sends everything on a reset turn, which throws the live thread away', async () => {
+    // threadHasHistory is computed from the session as it was BEFORE the reset stops it, so the
+    // `!isReset` term is what keeps the handler from scoping against a conversation it is about to
+    // destroy. Driven through the handler because that ordering only exists here.
+    const { manager, sent } = fakeManager({ threadId: 'thread_abc' });
+    await handleChatCompletion(
+      manager,
+      { model: 'gpt-5.5', messages: twoRoundsThenUser },
+      { 'x-session-id': 'demo', 'x-session-reset': '1' },
+      fakeRes(),
+    );
+    expect(sent[0]).toContain('ROUND-ONE-PAYLOAD');
+    expect(sent[0]).toContain('ROUND-TWO-PAYLOAD');
+  });
+
+  it('leaves a plain conversation alone', async () => {
+    // No tool messages: the assembly line must not put an empty block, or a stray blank line, in
+    // front of the caller's text.
+    const { manager, sent } = fakeManager({ threadId: 'thread_abc' });
+    await handleChatCompletion(
+      manager,
+      {
+        model: 'gpt-5.5',
+        messages: [
+          { role: 'user', content: 'hello' },
+          { role: 'assistant', content: 'hi' },
+          { role: 'user', content: 'still there?' },
+        ],
+      },
+      { 'x-session-id': 'demo' },
+      fakeRes(),
+    );
+    expect(sent[0]).toBe('still there?');
+  });
+
+  // ── the handler derives threadHasHistory from THREE things: the session existing, the engine
+  //    having a native conversation at all, and nativeThreadIsLive() reading the stats. The two
+  //    tests below reach the two arms the codex fixtures above cannot, because a double whose
+  //    getStatus never throws and whose engine is always native leaves them dead.
+
+  it('sends everything when the manager cannot report the session state', async () => {
+    // getStatus() throws — a session that died between listSessions() and here. The catch must
+    // resolve to false (send everything), not to true (scope against a transcript nobody
+    // confirmed). Flipping that catch to `true` was invisible to every other test in this file.
+    const { manager, sent } = fakeManager({ threadId: 'thread_abc', throwOnStatus: true });
+    await handleChatCompletion(
+      manager,
+      { model: 'gpt-5.5', messages: twoRoundsThenUser },
+      { 'x-session-id': 'demo' },
+      fakeRes(),
+    );
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain('ROUND-ONE-PAYLOAD');
+    expect(sent[0]).toContain('ROUND-TWO-PAYLOAD');
+  });
+
+  it('sends everything to an engine that has no conversation to resume', async () => {
+    // `gemini-9.9-experimental` resolves to the gemini engine, which has no resume surface, so
+    // engineHasNativeConversation() is false and nothing may be scoped away however alive the
+    // session looks. Without this, dropping that predicate from the guard reached
+    // nativeThreadIsLive()'s `default: return true` arm and scoped a one-shot engine.
+    const { manager, sent } = fakeManager({ threadId: 'thread_abc' });
+    await handleChatCompletion(
+      manager,
+      { model: 'gemini-9.9-experimental', messages: twoRoundsThenUser },
+      { 'x-session-id': 'demo' },
+      fakeRes(),
+    );
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain('ROUND-ONE-PAYLOAD');
+    expect(sent[0]).toContain('ROUND-TWO-PAYLOAD');
+  });
+});
+
+// The trade this fix accepts, pinned rather than described. A client that does not record the
+// engine's assistant reply in the array it re-sends is indistinguishable, from here, from one whose
+// engine never saw that round — so the round goes out a second time. Duplicating a round costs
+// redundant context; dropping it made the model answer without them and still return 200. The
+// second half of this test is the part that matters: the duplication is bounded to ONE round —
+// but only where the scoping runs, i.e. `threadHasHistory === true`. Every test below passes
+// `true` for that reason. With `false` there is no bound to state, because nothing is scoped away
+// and the whole array goes out by design: the engine holds nothing, so no round in it is a
+// duplicate. The third case pins the other edge, where the bound does not hold even on a live
+// thread: an array with no `assistant` message gives the scoping no boundary to slice at.
+describe('extractUserMessage — the duplicate-once trade', () => {
+  const call = (id: string): OpenAIChatMessage => ({
+    role: 'assistant',
+    content: null,
+    tool_calls: [{ id, type: 'function', function: { name: 'x', arguments: '{}' } }],
+  });
+
+  it('re-sends one round when the client omits the engine reply, and only one', () => {
+    const hop1: OpenAIChatMessage[] = [
+      { role: 'user', content: 'go' },
+      call('c1'),
+      { role: 'tool', tool_call_id: 'c1', content: 'ROUND-ONE' },
+    ];
+    expect(extractUserMessage(hop1, {}, true).userMessage).toContain('ROUND-ONE');
+
+    // Same array plus a user turn, engine reply not recorded: ROUND-ONE goes out again.
+    const hop2: OpenAIChatMessage[] = [...hop1, { role: 'user', content: 'and now?' }];
+    expect(extractUserMessage(hop2, {}, true).userMessage).toContain('ROUND-ONE');
+
+    // But a round the engine demonstrably closed is still not re-sent.
+    const withClosedRound: OpenAIChatMessage[] = [
+      { role: 'user', content: 'go' },
+      call('c0'),
+      { role: 'tool', tool_call_id: 'c0', content: 'ROUND-ZERO' },
+      call('c1'),
+      { role: 'tool', tool_call_id: 'c1', content: 'ROUND-ONE' },
+      { role: 'user', content: 'and now?' },
+    ];
+    const out = extractUserMessage(withClosedRound, {}, true);
+    expect(out.userMessage).not.toContain('ROUND-ZERO');
+    expect(out.userMessage).toContain('ROUND-ONE');
+  });
+
+  it('is not bounded at all with no history, and not bounded on a live thread with no assistant', () => {
+    const twoClosedRounds: OpenAIChatMessage[] = [
+      { role: 'user', content: 'go' },
+      call('c0'),
+      { role: 'tool', tool_call_id: 'c0', content: 'ROUND-ZERO' },
+      call('c1'),
+      { role: 'tool', tool_call_id: 'c1', content: 'ROUND-ONE' },
+      { role: 'user', content: 'and now?' },
+    ];
+    // threadHasHistory=false: nothing is scoped away, so "one round" is not the claim. Both go out,
+    // and that is correct — the engine holds neither.
+    const noHistory = extractUserMessage(twoClosedRounds, {}, false).userMessage;
+    expect(noHistory).toContain('ROUND-ZERO');
+    expect(noHistory).toContain('ROUND-ONE');
+
+    // Live thread, but the client never echoes the assistant turn it is answering: lastIndexOf()
+    // finds no boundary, slice(0) keeps everything, and the bound does not hold here either.
+    const noAssistantEver: OpenAIChatMessage[] = [
+      { role: 'user', content: 'go' },
+      { role: 'tool', tool_call_id: 'c0', content: 'ROUND-ZERO' },
+      { role: 'tool', tool_call_id: 'c1', content: 'ROUND-ONE' },
+      { role: 'user', content: 'and now?' },
+    ];
+    const live = extractUserMessage(noAssistantEver, {}, true).userMessage;
+    expect(live).toContain('ROUND-ZERO');
+    expect(live).toContain('ROUND-ONE');
   });
 });

--- a/src/openai-compat.ts
+++ b/src/openai-compat.ts
@@ -411,7 +411,11 @@ export function extractUserMessage(
    * Whether the engine's conversation already holds everything up to the caller's latest tool
    * round. Only meaningful for engines that resume a native conversation and only once the
    * conversation id has been captured — see nativeThreadIsLive(). Defaults to false so any caller
-   * that cannot establish that keeps the previous behaviour of sending every result.
+   * that cannot establish that keeps the safe behaviour of sending every result.
+   *
+   * This — not the shape of the caller's array — is what says whether a tool result is already in
+   * the engine's transcript. They are different questions: an array can end in a `user` turn on a
+   * thread that holds nothing at all.
    */
   threadHasHistory = false,
 ): ExtractedMessage {
@@ -437,10 +441,7 @@ export function extractUserMessage(
   const systemMessages = messages.filter((m) => m.role === 'system');
   const systemPrompt = systemMessages.length > 0 ? systemMessages.map(textOf).join('\n') : undefined;
 
-  // Handle tool result messages — only when the LAST non-system message is
-  // a tool role (meaning we're in an active tool-use cycle). If the last
-  // message is a user role, it's a follow-up in an existing conversation
-  // and the old tool results are already in the CLI's history.
+  // Tool results that end the array: an active tool-use cycle, with no new caller text to carry.
   const lastNonSystem = [...messages].reverse().find((m) => m.role !== 'system');
   if (lastNonSystem?.role === 'tool') {
     const toolResultBlock = serializeToolResults(messages, threadHasHistory);
@@ -455,13 +456,33 @@ export function extractUserMessage(
   if (userMessages.length === 0) {
     throw new Error('No user message found in messages array');
   }
-  const userMessage = textOf(userMessages[userMessages.length - 1]);
+  const lastUserText = textOf(userMessages[userMessages.length - 1]);
 
   // 1. Explicit reset header — honored in both modes. Normalize trim+lowercase
   //    so callers using `TRUE`, ` 1 `, etc. don't silently fail.
   const rawReset = headers?.['x-session-reset'];
   const resetHeader = typeof rawReset === 'string' ? rawReset.trim().toLowerCase() : '';
-  if (resetHeader === 'true' || resetHeader === '1') {
+  const isReset = resetHeader === 'true' || resetHeader === '1';
+
+  // Tool results that did NOT end the array — the caller appended a `user` or `assistant` turn
+  // after them. Whether they are already in the CLI's history is a question about the ENGINE, so
+  // `threadHasHistory` decides it, not the trailing role: an array ending in `user` says nothing
+  // about whether a transcript exists to have held the earlier rounds.
+  //
+  // A reset zeroes it: the session is about to be stopped and recreated, so on that turn the
+  // engine holds nothing regardless of what it held a moment ago. serializeToolResults() returns
+  // '' when there is nothing to send, so a request with no tool results is untouched, and on a
+  // live thread the existing scoping still trims everything before the engine's last assistant
+  // turn. What that bounds the hop to is precisely "the results that follow the engine's last
+  // `assistant` turn" — one round for a client that echoes each `assistant` turn it answers, and
+  // one round of N results for a single `assistant` announcing N parallel calls. It bounds nothing
+  // when no `assistant` message sits after the earliest unsent `tool` message, because then
+  // lastIndexOf('assistant') is behind them all and the slice keeps everything.
+  const toolResultBlock = serializeToolResults(messages, threadHasHistory && !isReset);
+  const userMessage =
+    toolResultBlock && lastUserText ? `${toolResultBlock}\n\n${lastUserText}` : toolResultBlock || lastUserText;
+
+  if (isReset) {
     return { systemPrompt, userMessage, isNewConversation: true };
   }
 


### PR DESCRIPTION
`extractUserMessage()` decides whether to forward the caller's tool results by reading the **shape**
of the messages array — is the last non-system message a `tool` role? — to answer a question about
the **engine's** state — does its transcript already hold them? On a thread that has no transcript
the two come apart. On such a thread an array ending in `tool` still sends everything; it is the
`[..., tool, user]` and `[..., tool, assistant]` shapes that lose every result, while the request
still returns `200`.

## Reproduced at runtime

Over real HTTP against `handleChatCompletion`, with a `SessionManager` double that records what
reaches `sendMessage()`. The only variable between the two blocks is whether the engine has a
conversation to resume; the message arrays are identical.

```
### main @ 7f83bd7 (v6.0.1)
  -- engine has NO conversation --
  [.., tool]            ends in tool        HTTP 200 | R1 reached the CLI: true  | R2: true  | prompt: false
  [.., tool, user]      ends in user        HTTP 200 | R1 reached the CLI: false | R2: false | prompt: true
  [.., tool, assistant] ends in assistant   HTTP 200 | R1 reached the CLI: false | R2: false | prompt: false
  -- engine IS resuming a live conversation --
  [.., tool]            ends in tool        HTTP 200 | R1 reached the CLI: false | R2: true  | prompt: false
  [.., tool, user]      ends in user        HTTP 200 | R1 reached the CLI: false | R2: false | prompt: true
  [.., tool, assistant] ends in assistant   HTTP 200 | R1 reached the CLI: false | R2: false | prompt: false

### this branch
  -- engine has NO conversation --
  [.., tool]            ends in tool        HTTP 200 | R1 reached the CLI: true  | R2: true  | prompt: false
  [.., tool, user]      ends in user        HTTP 200 | R1 reached the CLI: true  | R2: true  | prompt: true
  [.., tool, assistant] ends in assistant   HTTP 200 | R1 reached the CLI: true  | R2: true  | prompt: false
  -- engine IS resuming a live conversation --
  [.., tool]            ends in tool        HTTP 200 | R1 reached the CLI: false | R2: true  | prompt: false
  [.., tool, user]      ends in user        HTTP 200 | R1 reached the CLI: false | R2: true  | prompt: true
  [.., tool, assistant] ends in assistant   HTTP 200 | R1 reached the CLI: false | R2: false | prompt: false
```

Rows 2 and 3 of the first block are the bug: two rounds of results the engine has never seen, gone
— and in row 2 the CLI is handed "now summarize" with nothing to summarize. The live half is the
part that must not regress, and it does not: the round the engine already holds (`R1`) never goes
out, and the last row — a trailing `assistant`, which is the engine's own turn — is byte-identical
between the two blocks, sending nothing at all.

## The premise the diff deletes

`src/openai-compat.ts` on `main`:

```ts
  // Handle tool result messages — only when the LAST non-system message is
  // a tool role (meaning we're in an active tool-use cycle). If the last
  // message is a user role, it's a follow-up in an existing conversation
  // and the old tool results are already in the CLI's history.
```

"It's a follow-up **in an existing conversation**" is the load-bearing clause, and it is an
assumption about the engine that the array cannot support. A `[..., tool, user]` array says the
caller has a transcript. It says nothing about whether the CLI does.

The function already had a parameter for exactly that question, added in 4.12.0 and documented on
`main` today:

```ts
  /**
   * Whether the engine's conversation already holds everything up to the caller's latest tool
   * round. Only meaningful for engines that resume a native conversation and only once the
   * conversation id has been captured — see nativeThreadIsLive(). Defaults to false so any caller
   * that cannot establish that keeps the previous behaviour of sending every result.
   */
  threadHasHistory = false,
```

`serializeToolResults()` states the same thing from the other side — *"On a thread that already
holds the conversation, every tool result before the engine's most recent assistant turn is already
in the transcript."* Both are keyed on the thread. The shape test above them was keyed on the
array, and reached the opposite conclusion on any thread that held nothing. This PR deletes the
shape test and lets `threadHasHistory` decide, which is what the parameter was for.

## Evidence, with its denominator

One deployment: a Cloud Run gateway running the published package with `engine: codex`, patched
locally with one extra log line and no behaviour change. The line itself is not static across the
window: seven revisions appear in the data, the session-state and reset-header fields only exist
from `codex-shim-00113-jaj` (2026-08-17T17:49Z), and the line only moved outside the `tools` gate at
`codex-shim-00119-yop` (2026-08-22T19:43Z). Both consequences are quantified below. **Window: 2026-08-05T00:00:00Z through
2026-08-22T23:59:59Z, 18 complete UTC days** — chosen as every complete UTC day the log field has
existed (its first row is 2026-08-04T19:39:59Z, and 08-23 was in progress), not as the window that
produces the largest number. Pulled one `gcloud logging read` per UTC day at `--limit=20000`; the
busiest day returned 1,199 rows, so no day was truncated. The gateway's own smoke, probe and
load-test sessions are excluded.

| measure | value |
|---|---|
| fleet requests carrying ≥1 tool result | **8,377** |
| of those, every result discarded | **715** (8.5%) |
| characters carried / discarded | 440,110,421 / **44,672,264** (10.2%) |
| trailing role on the discards | 418 `user`, 297 `assistant` |

Now the denominators, because the traffic is lopsided:

- **10 of the 12 agents** that ever sent tool results hit it (14 agents sent traffic at all), on 17
  of the 18 days.
- **One agent is 74.2% of the discarded characters** (33.1M of 44.7M) and 44.6% of the discards.
- **One half-hourly cron is 272 of the 715 discards (38.0%)**, re-sending one of two near-identical
  payloads — 263 of its 271 gaps are exactly 30 minutes, at :17 and :47. It is only **7.7% of the
  characters**. Removing it entirely still leaves 443 discards across 10 agents on 16 of 18 days.
- The discards span **711 distinct session keys, which is not 711 callers.** This caller's session
  id embeds a per-conversation hash, so that count is an artifact of its own keying. It is in the
  data and I am not citing it as breadth.

The number that survives every denominator: **on 710 of the 715 the engine had no live conversation
at all** — the gateway logs the same `nativeThreadIsLive` result this fix keys on, and those 710
carry 44,672,215 of the 44,672,264 discarded characters. On the 337 discards from the revisions
that also log session state, 337 of 337 had no session and an engine turn count of 0. Those three
fields are perfectly collinear across all 3,850 state-logged rows, so that is the instruments
agreeing rather than a second independent denominator. The contrast is the informative half: of the
results *delivered* on the same revisions, 48 of 2,905 looked that way.

The results are dropped by falling THROUGH the trailing-`tool` shape test, not by an early return
of their own. That test is byte-identical in `v4.12.2` and `v5.0.0` — the two
versions this gateway ran during the window — and in `7f83bd7` (v6.0.1), this PR's base. So the
whole window measures the code path the PR changes, and the change lands on the same code that was
measured.

## What changes, and what does not

- Requests with **no** tool results: untouched. `serializeToolResults()` returns `''`, and the
  assembly line keeps an empty block out of the message. A regression test asserts the negative on
  both sides of `threadHasHistory`, because the obvious simplification — an unconditional
  `${block}\n\n${text}` — fails **three of this file's pre-existing tests** (eight once this PR's
  own are counted): every plain message would arrive with a leading blank line. Measured, not
  assumed.
- **Active tool cycle** (`[..., tool]`): untouched, both branches.
- **Live thread, trailing `user`**: was "drop everything", is now "send the round after the
  engine's last `assistant` turn". Asserted at 10 rounds × 30k: one round out, under 31,000
  characters, not ten.
- **`X-Session-Reset` on a trailing-`user` turn**: the session is about to be stopped and
  recreated, so the scoping is zeroed and everything goes out. Scoping against the thread the
  caller just asked to discard would be the same drop with extra steps.
- **The v2.11.1 regression cannot come back.** That release fixed "stale tool results re-injected
  on user follow-ups", and the shape test was the only signal available then. On a live thread the
  exact v2.11.1 shape — engine answered, user follows up — still sends nothing, because everything
  before the engine's own `assistant` turn is scoped away. Pinned by a test.

## Residual gaps, declared

1. **A round can go out twice.** A client that does not record the engine's reply in the array it
   re-sends is indistinguishable, from here, from one whose engine never saw that round. The
   duplication is bounded to one round; a test asserts both halves. Duplicating a round costs
   context, dropping it cost the results entirely.
2. **`latestRoundOnly` is not unconditional, and the CHANGELOG now says so.** It slices from
   `lastIndexOf('assistant')`, so an array carrying no `assistant` message gives `-1`, `slice(0)`,
   and the whole loop on every hop. Unchanged by this PR on both shapes, now pinned by a test
   instead of assumed.
3. **On a live thread, `[..., tool, assistant]` still sends nothing** — the trailing `assistant` is
   the engine's own turn, which it could not have produced without those results. Pinned by a test
   so anyone who needs the other answer sees it first.
4. **Not addressed here:** on an array whose last non-system message *is* a `tool` result, the
   reset header is read after that branch returns, so `X-Session-Reset` is not seen on that turn.
   That is a defect in where the header is parsed, not in this decision. It is *documented* here —
   one CHANGELOG bullet and one paragraph in the reference — because the docs it contradicts are
   docs this PR is already rewriting; only the code fix is a separate PR.

## What I cannot claim

- **No demonstrated wrong answer.** The telemetry records what reached the CLI, not what the model
  produced. There is no turn where I can show "it answered X and should have answered Y". What is
  demonstrated is that the results did not reach the CLI on a thread that could not have held them.
- **The overall request denominator is biased and I am not quoting a rate against it.** Until
  2026-08-22 the log line sat inside the tools gate, so a request with no `tools` left no row. The
  8,377 / 715 counts should not be affected, because a `tool` role message answers a `tool_calls`
  turn and therefore implies the caller declared `tools`. That argument stands on its own; the spot
  check I would have offered for it does not. Only **5** rows in the whole dataset report no tools,
  and all five are the gateway's own probe and smoke sessions — the traffic excluded above — so it
  contains zero fleet requests and supports nothing. No "x% of all requests" figure is quoted here.
- **378 of the 715 predate the session-state fields.** For those, "no live conversation" rests on
  the tool-block mode field alone, and the reset header is not logged. No fleet caller emits that
  header: across the 5.3 days it is logged, 20 requests carried it and 0 came from a fleet session.
- **The 5 discards that were on a live thread** are one agent inside one 14-minute window, 49
  characters in total. They are in the 715.
- **One deployment, one engine.** Nothing here measures the other eight (`claude`, `codex-app`,
  `agy`, `opencode`, `cursor`, `grok`, `gemini`, `custom`). The argument for those is the code, not
  the data — and for `grok` the code has its own pre-existing gap, described in the reference: its
  resume id is absent from `SessionStats`, so `nativeThreadIsLive()` answers `true` from map
  presence alone.

## Verification

Rebased onto `7f83bd7` (v6.0.1). The four commands `.github/workflows/ci.yml` runs, clean tree, on
**both Node versions of the CI matrix** (22.23.2 and 24.5.0):

```
npm run build         → ok
npm run lint          → ok (no output)
npm run format:check  → All matched files use Prettier code style!
npm run test          → Test Files 75 passed (75) | Tests 1315 passed (1315)
                        (serially; in parallel see the flake note below)
```

Swap `src/openai-compat.ts` back to the version on `main` and this file's tests fail **23 of 117** —
they refute the current behaviour rather than describe it.

Each behavioural line was mutated one at a time, since a test that passes either way is not holding
anything:

| mutation | result |
|---|---|
| the whole assembly reverted to `main`'s `userMessage = textOf(userMessages[len - 1])` | 23 fail |
| `threadHasHistory && !isReset` → `threadHasHistory` (reset no longer zeroes the scoping) | 2 fail |
| `serializeToolResults(messages, …)` forced to `true` (scope as if the engine held it all) | 12 fail |
| drop the caller's text when a block is present | 9 fail |
| block and text concatenated in the reverse order | 2 fail |
| the parameter's documented default flipped, `false` → `true` | 1 fail |
| the legacy-heuristic branch alone reverted to the caller's text | 1 fail |
| separator between block and text, `\n\n` → `\n` | 1 fail |
| the handler's `catch` around `getStatus()` resolving to `true` instead of `false` | 1 fail |
| `engineHasNativeConversation()` dropped from the handler's guard | 1 fail |
| each tool payload truncated to its first 20 characters | 1 fail |
| the block's framing sentence replaced with one that negates it | 1 fail |

The last seven rows are there because a first pass had them **surviving**, and each one is a real
behaviour change:

- The ordering assertion was itself vacuous. It compared offsets, but on a build that drops the
  block `indexOf` returns `-1`, and `-1 < 0` passes — so the one guard for ordering passed on
  `main` too. It now asserts both offsets are non-negative first.
- The docstring this PR edits promises the parameter "defaults to false so any caller that cannot
  establish that keeps the safe behaviour of sending every result". Every existing default-argument
  call site passes a one-round array, where scoping is unobservable, so that promise was asserted
  nowhere. A two-round fixture makes it observable.
- The legacy webchat branch (`OPENAI_COMPAT_NEW_CONVO_HEURISTIC=1`) returns from its own statement.
  Reverting just that return restored the bug for exactly the clients most exposed to it — Open
  WebUI and ChatGPT-Next-Web re-send the whole transcript every turn — and left the file green.
- Every assertion on a block-carrying message was `toContain`, which cannot see the separator, the
  framing sentence, or a truncated payload. One exact-string assertion on the assembled message
  pins all three; its payload is deliberately longer than 20 characters, because every other
  fixture in the file is short enough that a truncating serializer passes.
- The handler derives `threadHasHistory` from three things — the session existing, the engine
  having a native conversation, and `nativeThreadIsLive()` reading the stats. Two of the three were
  unreachable through the test double: its `getStatus` never threw, and every fixture used a codex
  model. There is now a throwing variant and a `gemini` fixture.

**One thing you should know before merging, because it is caused by this PR and I could not make it
go away.** Adding 29 tests to the suite tips two pre-existing lock-race tests in
`invariants.test.ts` into failing, in this environment, through parallel load rather than anything
semantic. The causal chain is measured, not inferred:

```
invariants.test.ts alone, this branch            → 47 passed (47)          clean
full suite MINUS this PR's test file             → 1198 passed (1198)      clean
full suite, --maxWorkers=1                       → 1315 passed (1315)      clean
full suite, default parallelism, Node 22         → 8 of 8 runs flake
full suite, default parallelism, Node 24         → 6 of 8 runs flake
```

The two tests (`invariants.test.ts:1198`, `:1224`) spawn a child that must claim a file lock inside
`DEFAULT_LOCK_WAIT_MS = 250` (`src/kernel/file-lock.ts:42`) against holders held for 150 ms and
900 ms. Neither test mentions `openai-compat` — 0 references in the file — so what this PR
contributes is CPU and memory contention, on a 16-core WSL2 box with 7 GB of RAM, where vitest's
default worker count and that 250 ms window do not coexist comfortably.

It is not purely mine: on Node 24, pristine `7f83bd7` flakes the same two tests in **7 of 8** runs
with no changes at all. But on Node 22 pristine was clean **4 of 4** while this branch flaked 8 of
8, so on that version the added load is what tips it. I am not claiming the tests are fine and I am
not touching them here — fixing a lock-race window is not this PR's business, and I would rather you
see the measurement than a "pre-existing, ignore it" line. A CI runner with a different core/memory
ratio may never show it; I cannot verify that from here. `--maxWorkers=1` is clean on both versions
if you want a deterministic gate.

The other flake, seen once on this branch and twice on pristine in an earlier batch, is an unhandled
`write ECONNRESET` from `embedded-server.test.ts`: `src/embedded-server.ts:342` answers 415 and ends
the response without draining the request body, so the connection can be torn down while the client
is still writing. It fails the process exit code while every test still reports passing. Reported
separately.

The deterministic part, unaffected by any of the above: `src/__tests__/openai-compat.test.ts` is
**117 passed (117)** on both Node 22.23.2 and Node 24.5.0, every run.

`skills/references/openai-compat.md` gains a "Tool results on the way back" section per
`CONTRIBUTING.md`'s rule that a subsystem's reference file is its single source of truth: when the
results are serialized, what the scoping covers, the two properties of it a client should check, and
the `claude`/`grok` cases that reach a "live thread" verdict from map presence alone. Its tables are
Prettier-aligned to match the pass in `8ee2405`, though `format:check` does not glob markdown.

The runtime block above is trimmed for width — the harness prints a longer label per row and its
own header — but every value shown is what it printed.
