### PR TITLE
fix(test): stop the lock holder outliving the run that spawned it

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src/ bin/",
     "lint:fix": "eslint src/ bin/ --fix",
+    "typecheck:tests": "tsc -p tsconfig.test.json",
     "format": "prettier --write 'src/**/*.ts' 'bin/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts' 'bin/**/*.ts'",
     "prepublishOnly": "npm run build"

--- a/src/__tests__/invariants.test.ts
+++ b/src/__tests__/invariants.test.ts
@@ -152,6 +152,12 @@ function runFiles(runId: string): string[] {
 }
 
 /**
+ * Absolute lifetime for a spawned lock holder. Every test that uses one finishes
+ * far inside this; it exists only so a holder cannot outlive the run that made it.
+ */
+const HOLD_LOCK_MAX_MS = 30_000;
+
+/**
  * Hold a lock file from a real other process.
  *
  * Coordinated rather than timed, and both halves matter. `ready` resolves only once the
@@ -169,12 +175,38 @@ function holdLock(
   ready: Promise<void>;
   exited: Promise<void>;
 } {
+  // Checked here rather than left to the type system, because this file is not
+  // type-checked by the build and a call written against an older signature
+  // reached this line with `opts.releaseOn` undefined. `JSON.stringify(undefined)`
+  // returns undefined, which interpolates as the bare token `undefined`, so the
+  // child ran `existsSync(undefined)` — false forever, on a loop with nothing to
+  // stop it. A wrong call must fail this test, not quietly outlive it.
+  if (typeof opts?.releaseOn !== 'string' || !opts.releaseOn) {
+    throw new TypeError(`holdLock: releaseOn must be a non-empty path, got ${JSON.stringify(opts?.releaseOn)}`);
+  }
   const src = `
     const fs = await import('node:fs');
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const parentPid = ${process.pid};
+    const deadline = Date.now() + ${HOLD_LOCK_MAX_MS};
+    // Three ways out, not one. Waiting only on the release marker means a test
+    // that crashes, times out, or is interrupted never writes it, and this
+    // process holds the lock and its memory until the machine is rebooted —
+    // which is how 31 of them accumulated over four days. The parent check is
+    // what covers an abrupt kill; the deadline covers everything else.
+    const parentAlive = () => {
+      try {
+        process.kill(parentPid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    };
     fs.writeFileSync(${JSON.stringify(lockPath)}, '');
     console.log('HELD');
-    while (!fs.existsSync(${JSON.stringify(opts.releaseOn)})) await sleep(2);
+    while (!fs.existsSync(${JSON.stringify(opts.releaseOn)}) && Date.now() < deadline && parentAlive()) {
+      await sleep(2);
+    }
     await sleep(${opts.graceMs ?? 0});
     fs.rmSync(${JSON.stringify(lockPath)}, { force: true });
   `;
@@ -589,7 +621,12 @@ describe('crash recovery', () => {
       renewedAt: new Date().toISOString(),
     });
     expect(leaseIsStale(readLease(rec.runId))).toBe(true);
-    expect(() => acquireLease(rec.runId)).not.toThrow();
+    // The owner id is what makes this a takeover rather than a re-entry, and it
+    // was missing: `acquireLease` takes two arguments and this call passed one,
+    // so the claim went in under `undefined` and the assertion held for a
+    // reason the test does not describe.
+    expect(() => acquireLease(rec.runId, 'the-successor')).not.toThrow();
+    expect(readLease(rec.runId)?.ownerId).toBe('the-successor');
   });
 });
 
@@ -1519,15 +1556,22 @@ describe('races that need real processes', () => {
           owner: { ownerId: 'the-new-owner', pid: process.pid, renewedAt: new Date().toISOString() },
         }),
       );
-      const holder = holdLock(`${statePath}.lock`, 900);
-      await new Promise((r) => setTimeout(r, 60));
+      // Written against the helper's older signature — a hold duration in ms —
+      // which left `releaseOn` undefined and the holder looping forever. The
+      // `await holder` below compounded it: `holdLock` returns a pair of
+      // promises, not a promise, so awaiting the object resolved at once and
+      // the test finished green while the child it spawned stayed behind.
+      const release = path.join(dir, 'release-stale-owner');
+      const holder = holdLock(`${statePath}.lock`, { releaseOn: release });
+      await holder.ready;
 
       await expect(q.enqueue('stale-work')).rejects.toThrow(/locked by another process/);
       expect(seen).toEqual([]);
       const disk = JSON.parse(fs.readFileSync(statePath, 'utf8'));
       expect(disk.owner.ownerId).toBe('the-new-owner');
       expect(disk.pending).toEqual(['theirs']);
-      await holder;
+      fs.writeFileSync(release, '');
+      await holder.exited;
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -1633,4 +1677,38 @@ describe('races that need real processes', () => {
     // The rightful owner can still remove it.
     expect(kernel.delete('contested-id', { expectTag: 'start-2' })).toBe(true);
   }, 30_000);
+});
+
+// ─── The harness does not outlive the run ───────────────────────────────────
+
+describe('a spawned lock holder cannot become an orphan', () => {
+  // Two calls in this file were written against older signatures and neither
+  // failed: `holdLock(path, 900)` left `releaseOn` undefined, and the child then
+  // waited on `existsSync(undefined)` — false forever, on a loop with no other
+  // way out. It held ~62 MB and the lock file, once per run, until the machine
+  // was rebooted. Tests are not type-checked (see tsconfig.test.json), so the
+  // only thing that can catch a call like that is the helper itself.
+  it('refuses a call that would leave it waiting on nothing', () => {
+    const lock = path.join(wfDir, 'guard.lock');
+    // The shape the stale call actually had.
+    expect(() => holdLock(lock, 900 as unknown as { releaseOn: string })).toThrow(/releaseOn/);
+    expect(() => holdLock(lock, { releaseOn: '' })).toThrow(/releaseOn/);
+    expect(fs.existsSync(lock)).toBe(false);
+  });
+
+  it('exits on its own when the release signal never comes', async () => {
+    // Nothing writes this marker: the holder has to end itself. A test that
+    // crashes or is interrupted leaves exactly this state behind, which is the
+    // case a release-marker-only wait can never recover from.
+    const holder = holdLock(path.join(wfDir, 'deadline.lock'), {
+      releaseOn: path.join(wfDir, 'marker-that-is-never-written'),
+    });
+    await holder.ready;
+    await expect(
+      Promise.race([
+        holder.exited.then(() => 'exited'),
+        new Promise((r) => setTimeout(() => r('still running'), HOLD_LOCK_MAX_MS + 5_000)),
+      ]),
+    ).resolves.toBe('exited');
+  }, 60_000);
 });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,26 @@
+{
+  // Type-checks the test suite, which tsconfig.json excludes so that tests stay
+  // out of dist/. Nothing had ever checked them, and two calls written against
+  // signatures that had since changed were living in that gap:
+  //
+  //   holdLock(path, 900)          — an options object was expected, so
+  //                                  `releaseOn` was undefined and the child
+  //                                  process it spawns never exited. One orphan
+  //                                  per run, 31 of them over four days.
+  //   acquireLease(runId)          — takes two arguments; the claim went in
+  //                                  under an undefined owner id.
+  //
+  // Both are fixed. This config is a diagnostic, NOT a CI gate: run it and it
+  // still reports ~70 pre-existing errors, nearly all of them deliberate
+  // looseness in test doubles (a `FakeSession` implementing `Partial<ISession>`
+  // with narrower signatures, config literals omitting required fields). Making
+  // it green is a real piece of work and a separate one. Until then, run it
+  // after changing a test helper's signature and read the errors it adds.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*", "bin/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
`holdLock` spawns a real second process to contend for a lock. Its only way out was a release marker the test writes, so any run that did not reach that write left the child behind — holding ~60 MB and the lock file — until reboot. 31 had accumulated over four days.

Two calls in this file had been written against older signatures, and neither failed:

- **`holdLock(path, 900)`** passed a duration where an options object was expected, so `opts.releaseOn` was undefined. `JSON.stringify(undefined)` returns `undefined`, which interpolates as the bare token `undefined`, so the child ran `existsSync(undefined)` — which returns false rather than throwing, forever. The `await holder` on the next line compounded it: `holdLock` returns a pair of promises, not a promise, so awaiting the object resolved immediately and the test finished green while its child stayed behind.
- **`acquireLease(runId)`** dropped the required owner id, so the claim the test describes as a takeover went in under `undefined` and its assertion held for a reason the test does not state.

## What changed

The holder now has three ways out instead of one — the release marker, an absolute 30s deadline, and the parent going away — so a crashed, timed-out or interrupted run cannot leave one behind either. A `releaseOn` that is not a usable path throws at the call, turning a silent leak into a failing test. Both stale calls are fixed, and the lease test now asserts the owner it claims to be testing.

## Why nothing caught it

`tsconfig.json` excludes `src/__tests__` so tests stay out of `dist/` — which also meant nothing type-checked them, and neither wrong call was visible to the compiler. `tsconfig.test.json` plus `npm run typecheck:tests` closes that blind spot. It is a diagnostic rather than a CI gate: it still reports ~70 pre-existing errors, nearly all deliberate looseness in test doubles, and making it green is separate work. Its header says so.

## Verification

Measured against the real child process: the deadline path exits on its own in 1535 ms, the parent-gone path in 56 ms, and the old shape only stopped when SIGKILLed (`code=null`). Both new tests were mutation-checked — removing either guard turns its own test red and no others. A full 1485-test run adds zero orphans, against one per run before.

No shipped source changed: the diff touches `src/__tests__/`, `tsconfig.test.json` and a `package.json` script only, so `dist/` is unaffected.