### PR TITLE
fix(bin): make the shipped commands executable and report the real version (v6.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.1] - 2026-08-27
+
+Both defects surfaced while connecting `clawo-mcp` to an MCP host for the first time.
+
+### Fixed
+
+- **The commands in `package.json#bin` were not executable.** `tsc` writes 0644 and the build never
+  restored the bit. A published install hides this — npm sets the mode itself when it links a bin —
+  but a `npm link` checkout points straight at these files, so after a build the commands sit on
+  PATH and refuse to run with "permission denied", while `command -v` reports them as missing
+  because it only considers executables. `clawo` had therefore only ever worked when invoked as
+  `node $(which clawo)`, and `clawo-mcp` / `clawo-acp` could not be run at all. `scripts/postbuild.mjs`
+  now marks all three executable.
+- **The MCP server reported the wrong version to every host.** It read
+  `process.env.npm_package_version`, which npm sets only for a process npm itself started; an MCP
+  host spawns the binary directly, so the variable was never present and the hard-coded fallback —
+  `3.7.0`, the version current when that line was written — was what got sent every time. It now
+  reads the package manifest, the way `bin/cli.ts` already did.
+
+### Fixed (test harness)
+
+- **A lock holder spawned by the test suite could outlive the run that made it.** `holdLock` waits
+  on a release marker the test writes, and that was its only way out, so a run that crashed, timed
+  out, or was interrupted left the child process holding memory and a lock file until reboot. Two
+  calls in that file had also been written against older signatures and neither failed: one passed
+  a duration where an options object was expected, leaving the marker path undefined and the child
+  waiting on `existsSync(undefined)` — false forever; the other dropped a required owner id, so the
+  takeover a test describes went in under `undefined`. The holder now also exits on an absolute
+  deadline or when its parent goes away, and an unusable marker path throws at the call rather than
+  leaking silently. `tsconfig.test.json` plus `npm run typecheck:tests` closes the blind spot that
+  hid both calls — tests are excluded from the build so that they stay out of `dist/`, which also
+  meant nothing type-checked them. It is a diagnostic, not a CI gate; its header explains why.
+
 ## [6.1.0] - 2026-08-27
 
 Engine sweep: Claude Code 2.1.237 → 2.1.246, Codex 0.148.0 → 0.149.1, Antigravity 1.1.15 → 1.1.21,

--- a/bin/mcp-server.ts
+++ b/bin/mcp-server.ts
@@ -22,6 +22,8 @@
  *                            control-plane (port 18796) which is dead weight
  *                            for MCP-only deployments.
  */
+import { createRequire } from 'node:module';
+
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -136,7 +138,25 @@ if (allowed && tools.length === 0) {
   log.warn(`CLAWO_MCP_TOOLS filter matched 0 tools. Captured: ${captured.map((t) => t.name).join(', ')}`);
 }
 
-const PKG_VERSION = process.env.npm_package_version ?? '3.7.0';
+/**
+ * The version reported to the MCP host.
+ *
+ * `npm_package_version` is only set for a process npm itself started, and an MCP
+ * host spawns this binary directly — so that variable is never present here and
+ * the literal fallback was what every host had been told since it was written.
+ * Read the package's own manifest instead, the way `bin/cli.ts` does.
+ */
+function pkgVersion(): string {
+  try {
+    // From dist/bin/mcp-server.js, package.json sits two levels up.
+    const pkg = createRequire(import.meta.url)('../../package.json') as { version?: string };
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+const PKG_VERSION = pkgVersion();
 
 const server = new Server({ name: 'claw-orchestrator', version: PKG_VERSION }, { capabilities: { tools: {} } });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enderfga/claw-orchestrator",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Claw Orchestrator \u2014 run Claude Code, Codex, Gemini, Cursor Agent, OpenCode and custom coding CLIs as one unified runtime. Drop into Hermes Agent, Claude Desktop, Cursor, Cline, Continue, Zed, Windsurf, Goose or any Model Context Protocol (MCP) host, install as an OpenClaw plugin, or run standalone. Persistent sessions, multi-agent council, ultraplan, ultrareview, autoloop, tool orchestration.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -4,7 +4,7 @@
 // rather than reading package.json#main, so this shim lets the same package
 // satisfy both Node module resolution (via package.json#main) and OpenClaw.
 // See https://github.com/Enderfga/claw-orchestrator/issues/57
-import { writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs';
+import { writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync, chmodSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -41,4 +41,23 @@ if (existsSync(srcDash)) {
   copyTree(srcDash, distDash);
 }
 
-console.log(`[postbuild] wrote dist/index.js + dist/index.d.ts shims; copied ${copied} dashboard asset(s)`);
+// Restore the executable bit on the package's bin entries.
+//
+// tsc writes 0644, so every build strips it. On a published install that goes
+// unnoticed — npm sets the mode itself when it links a `bin` — but a local
+// `npm link` checkout points straight at these files, so after a build the
+// commands are on PATH and refuse to run ("permission denied"), and `command -v`
+// reports them as missing because it only considers executables. That is how
+// `clawo` came to work only when invoked as `node $(which clawo)`.
+const bins = ['cli.js', 'mcp-server.js', 'acp-server.js'];
+let marked = 0;
+for (const b of bins) {
+  const f = resolve(dist, 'bin', b);
+  if (!existsSync(f)) continue;
+  chmodSync(f, 0o755);
+  marked++;
+}
+
+console.log(
+  `[postbuild] wrote dist/index.js + dist/index.d.ts shims; copied ${copied} dashboard asset(s); marked ${marked} bin(s) executable`,
+);


### PR DESCRIPTION
Both defects surfaced while connecting `clawo-mcp` to an MCP host for the first time — neither was reachable from anything the test suite or CI does.

## The bins were not executable

`tsc` writes 0644 and the build never restored the bit. A published install hides this — npm sets the mode itself when it links a `bin` — but a `npm link` checkout points straight at these files, so after a build the commands sit on PATH and refuse to run with "permission denied", while `command -v` reports them as missing because it only considers executables.

`clawo` had therefore only ever worked when invoked as `node $(which clawo)`, and `clawo-mcp` / `clawo-acp` could not be run at all. `scripts/postbuild.mjs` now marks all three executable; the packed tarball carries `-rwxr-xr-x` on each.

## The MCP server reported the wrong version to every host

It read `process.env.npm_package_version`, which npm sets only for a process npm itself started. An MCP host spawns the binary directly, so the variable was never present and the hard-coded fallback — `3.7.0`, the version current when that line was written — was what got sent on every handshake. It now reads the package manifest, the way `bin/cli.ts` already did. A live handshake reports the real version.

## Verification

`clawo`, `clawo-mcp` and `clawo-acp` all resolve through `command -v` and run directly. A real MCP `initialize` returns the correct `serverInfo.version`, and `tools/list` returns the full surface. 1485 tests pass.