### PR TITLE
feat: add ZCode community engine preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **ZCode community engine preset.** The preset uses the contributor-maintained
+  `@bwndlct/zcode-claw-adapter` package and was verified against ZCode 0.16.5 with a published,
+  two-turn context smoke record.
+
 ## [6.3.0] - 2026-09-02
 
 ### Added

--- a/configs/engines/zcode.json
+++ b/configs/engines/zcode.json
@@ -1,0 +1,30 @@
+{
+  "id": "zcode",
+  "tier": "community",
+  "description": "ZCode app-server support through the community-maintained Claw adapter.",
+  "provenance": {
+    "maintainer": "bwndlct",
+    "verifiedAgainst": "ZCode 0.16.5",
+    "verifiedOn": "2026-09-03",
+    "sourceUrl": "https://github.com/bwndlct/zcode-claw-adapter",
+    "smokeUrl": "https://gist.github.com/bwndlct/e57e719ff43db87c7b0f80622d3f15f0"
+  },
+  "engine": {
+    "name": "zcode",
+    "bin": "zcode-claw-adapter",
+    "binEnv": "ZCODE_CLAW_ADAPTER_BIN",
+    "persistent": true,
+    "contextWindow": 200000,
+    "args": {
+      "resume": "--resume",
+      "model": "--model",
+      "permissionMode": "--mode"
+    },
+    "permissionModes": {
+      "plan": "plan",
+      "default": "build",
+      "acceptEdits": "edit",
+      "bypassPermissions": "yolo"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add the first community preset for ZCode
- point the preset at the contributor-maintained `@bwndlct/zcode-claw-adapter` package
- include dated provenance for ZCode 0.16.5 and a public two-turn context smoke record
- document the new preset under `Unreleased`

The protocol translation remains in the adapter package; this PR only adds the portable preset and its provenance.

Smoke record: https://gist.github.com/bwndlct/e57e719ff43db87c7b0f80622d3f15f0
Adapter source: https://github.com/bwndlct/zcode-claw-adapter
Published package: https://www.npmjs.com/package/@bwndlct/zcode-claw-adapter

The smoke used the installed Claw 6.3.0 MCP `session_start` / `session_send` / `session_stop` tools because the published 6.3.0 CLI does not expose the `--custom-engine` option shown in `CONTRIBUTING.md`. The linked record calls this out explicitly.

Closes #93

## Verification

- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run test`
- clean npm-registry install of `@enderfga/claw-orchestrator@6.3.0` and `@bwndlct/zcode-claw-adapter@0.1.0`
- two-turn live ZCode smoke: `OK`, then `4173`, same real `sess_...` id