### PR TITLE
feat: make `-e custom` reachable from the CLI (v6.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.4.0] - 2026-09-03
 
 ### Added
 
-- **ZCode community engine preset.** The preset uses the contributor-maintained
-  `@bwndlct/zcode-claw-adapter` package and was verified against ZCode 0.16.5 with a published,
-  two-turn context smoke record.
+- **ZCode community engine preset**, the first one, contributed by @bwndlct. It points at the
+  contributor-maintained `@bwndlct/zcode-claw-adapter` package and carries provenance for ZCode
+  0.16.5 with a published two-turn context smoke record. The protocol translation lives in that
+  package, which is the split the community tier exists to make possible.
+- **`clawo engines`** lists the bundled presets with each one's provenance — who attested it,
+  against which engine version, on what date. Read from the installed package rather than over HTTP,
+  so it works with no server running.
+- **`clawo session-start --custom-engine <preset-id>`.** `-e custom` was offered by the CLI and
+  could not be satisfied by it: there was no option to supply the engine, so the path failed with
+  "customEngine config is required". Found by @bwndlct, twice — first while preparing the ZCode
+  preset, then in a follow-up PR to correct the guide. The contribution path's first outside user
+  walked straight into it, which is roughly the point of having one.
+
+### Changed
+
+- **The HTTP guard now refuses inline custom-engine configs specifically, rather than the whole
+  field.** Its reason has always been that a custom engine names an executable to spawn — but
+  `engine: 'codex'` spawns one too and is accepted, so spawning was never the line; arbitrary argv
+  is. A preset id cannot carry any: it selects one of the descriptions this package ships. Inline
+  configs remain local-only, and a preset id is now the supported way to reach a custom engine from
+  the CLI. Verified both directions against a running server: an inline config carrying
+  `/bin/sh -c "touch …"` is refused and writes nothing, while a preset id reaches the spawn.
+
+### Fixed
+
+- **The smoke script in CONTRIBUTING.md named a command that does not exist.** It used
+  `clawo session start` (the command is `session-start`) and a `--custom-engine` option that had not
+  been implemented. It was written without being run. It now matches the CLI, starts from
+  `clawo engines` to confirm the preset loads at all, and says why the preset — not an inline config
+  — is what has to be smoked.
 
 ## [6.3.0] - 2026-09-02
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,16 +100,35 @@ Do not open a PR that puts protocol translation for an untestable engine into
 A preset is accepted on a falsifiable claim, so `provenance` must carry one.
 Run this against your engine and link the captured output:
 
+Drop your preset into `configs/engines/` in a checkout, build, and run:
+
 ```bash
+# 0. your preset has to be loadable before it can be smoked
+npm run build && clawo engines          # your id should be listed
+
 # 1. two turns, to prove the session actually carries context
-clawo session start --name preset-smoke --engine custom --custom-engine ./my-preset.json
-clawo session send --name preset-smoke "Remember the number 4173. Reply with just OK."
-clawo session send --name preset-smoke "What number did I ask you to remember?"   # must answer 4173
-clawo session stop --name preset-smoke
+clawo session-start preset-smoke -e custom --custom-engine <your-preset-id>
+clawo session-send preset-smoke "Remember the number 4173. Reply with just OK."
+clawo session-send preset-smoke "What number did I ask you to remember?"   # must answer 4173
+clawo session-stop preset-smoke
 
 # 2. the version you ran it against
 my-engine --version
 ```
+
+Smoke the **preset**, not an inline config. They are not the same evidence: a
+preset additionally has to load from disk, match its filename, and resolve by
+id, and those are the parts a preset can get wrong.
+
+A preset id is the only form of custom engine the CLI can pass, and that is on
+purpose. `clawo` reaches the session through the HTTP control plane, which
+refuses an inline `customEngine` object because such an object names an
+executable and its arguments — only a local caller (the MCP tool, or the
+`SessionManager` API in-process) may configure one of those. A preset id carries
+neither a binary nor argv; it selects one of the descriptions this package
+ships, which is the same class as naming a built-in engine. If you need to
+iterate on a draft before it is a file, use the MCP `session_start` tool with an
+inline `customEngine` — that path is local and accepts one.
 
 Paste both into a gist and put its URL in `provenance.smokeUrl`, the engine
 version in `provenance.verifiedAgainst`, and the date in `provenance.verifiedOn`.

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -186,10 +186,18 @@ program
   .option('--resume-session-id <id>', 'Resume existing session by ID')
   .option('--base-url <url>', 'Custom API endpoint (for proxy)')
   .option('--add-dir <dirs>', 'Comma-separated additional working directories')
+  .option(
+    '--custom-engine <preset>',
+    'With -e custom: the id of a bundled engine preset (see `clawo engines`). Inline configs are not accepted here — that is what presets are for',
+  )
   .action(async (name, opts) => {
     const body: Record<string, unknown> = { name: name || `session-${Date.now()}` };
     if (opts.cwd) body.cwd = opts.cwd;
     if (opts.engine) body.engine = opts.engine;
+    // Only a preset id. An inline config names a binary and its arguments, and
+    // this command reaches the session through the same HTTP surface that
+    // refuses those — see `clawo engines` for what is available.
+    if (opts.customEngine) body.customEngine = opts.customEngine;
     if (opts.model) body.model = opts.model;
     if (opts.permissionMode) body.permissionMode = opts.permissionMode;
     if (opts.effort) body.effort = opts.effort;
@@ -333,6 +341,37 @@ program
 function fail(r: { error?: string }): void {
   console.error(`Failed: ${r.error}`);
 }
+
+program
+  .command('engines')
+  .description('List the community engine presets bundled with this package')
+  .option('--json', 'Emit raw JSON instead of a table')
+  .action(async (opts) => {
+    // Read locally rather than over HTTP: this is a property of the installed
+    // package, and it has to work whether or not a server is running.
+    const { listEnginePresets } = await import('../src/engine-presets.js');
+    const presets = listEnginePresets();
+    if (opts.json) {
+      console.log(JSON.stringify(presets, null, 2));
+      return;
+    }
+    if (!presets.length) {
+      console.log('No engine presets are bundled with this build.');
+      return;
+    }
+    console.log('Community presets — schema-validated here, but not run here.');
+    console.log("What each one claims is its maintainer's dated attestation:\n");
+    for (const p of presets) {
+      console.log(`  ${p.id}`);
+      console.log(`    ${p.description}`);
+      console.log(
+        `    verified by ${p.provenance.maintainer} against ${p.provenance.verifiedAgainst} on ${p.provenance.verifiedOn}`,
+      );
+      if (p.provenance.smokeUrl) console.log(`    smoke: ${p.provenance.smokeUrl}`);
+      console.log(`    use:   clawo session-start my-session -e custom --custom-engine ${p.id}`);
+      console.log('');
+    }
+  });
 
 program
   .command('runs')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enderfga/claw-orchestrator",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Claw Orchestrator \u2014 run Claude Code, Codex, Gemini, Cursor Agent, OpenCode and custom coding CLIs as one unified runtime. Drop into Hermes Agent, Claude Desktop, Cursor, Cline, Continue, Zed, Windsurf, Goose or any Model Context Protocol (MCP) host, install as an OpenClaw plugin, or run standalone. Persistent sessions, multi-agent council, ultraplan, ultrareview, autoloop, tool orchestration.",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/skills/references/cli.md
+++ b/skills/references/cli.md
@@ -240,3 +240,21 @@ clawo runs --refuted      # only turns whose acceptance contract failed
 The table gains a `VERIFIED` column with three values: `yes`, `NO`, and `—` for
 "no contract was declared, so nothing checked it". See
 [`observability.md`](./observability.md).
+
+## `clawo engines`
+
+Lists the community engine presets bundled with the installed package, with each
+one's provenance — who attested it, against which engine version, on what date.
+Read locally rather than over HTTP, since it is a property of the package and has
+to work with no server running.
+
+```bash
+clawo engines
+clawo engines --json
+clawo session-start my-session -e custom --custom-engine <id>
+```
+
+A preset id is the only form of custom engine the CLI can pass: it reaches the
+session through the HTTP surface, which refuses inline configs because those name
+a binary and its arguments. See [multi-engine.md](./multi-engine.md) for the tiers
+and what a community preset does and does not claim.

--- a/skills/references/multi-engine.md
+++ b/skills/references/multi-engine.md
@@ -300,9 +300,13 @@ needs an adapter binary in its author's package, with the preset pointing `bin`
 at it — the split `@enderfga/dsh-clawo` already uses. That is what makes a preset
 something this project can ship without owning a protocol it cannot test.
 
-A preset id is refused over HTTP exactly as an inline config is. Naming a
-shipped description is tamer than arbitrary argv, but it is still a remote caller
-causing a process to spawn.
+Over HTTP — which includes the `clawo` CLI — a custom engine may be given **only**
+as a preset id. An inline config names a binary and its arguments and is refused
+there; a preset id cannot introduce either, so it is the same class as naming a
+built-in engine, and `engine: 'codex'` already spawns an executable over that
+surface. Presets are therefore the supported way to reach a custom engine from
+the CLI: `clawo engines` lists what is bundled, and
+`clawo session-start <name> -e custom --custom-engine <id>` starts one.
 
 Contribution steps and the smoke script: [CONTRIBUTING.md](../../CONTRIBUTING.md#contributing-an-engine).
 

--- a/src/__tests__/embedded-server-launcher.test.ts
+++ b/src/__tests__/embedded-server-launcher.test.ts
@@ -263,7 +263,7 @@ describe('POST /autoloop/new', () => {
       expect(r.status).toBe(400);
       const payload = (await r.json()) as { ok: boolean; error: string };
       expect(payload.ok).toBe(false);
-      expect(payload.error).toContain('not accepted over HTTP');
+      expect(payload.error).toContain('may not be given as an inline config over HTTP');
       expect(manager.autoloopStart).not.toHaveBeenCalled();
     }
   });
@@ -513,7 +513,7 @@ describe('POST /autoloop/:id/resume + GET /autoloop/:id/chat_history', () => {
 
     expect(r.status).toBe(400);
     const payload = (await r.json()) as { ok: boolean; error: string };
-    expect(payload.error).toContain('not accepted over HTTP');
+    expect(payload.error).toContain('may not be given as an inline config over HTTP');
     expect(resumeSpy).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/embedded-server.test.ts
+++ b/src/__tests__/embedded-server.test.ts
@@ -315,23 +315,23 @@ describe('EmbeddedServer', () => {
       expect(manager.startSession).not.toHaveBeenCalled();
     });
 
-    // Presets made `customEngine` accept a string as well as an object. A
-    // preset names a binary this project ships a description of, which is
-    // tamer than arbitrary argv — but it is still a remote caller causing a
-    // process to spawn, which is the thing this guard exists to stop. The
-    // guard matches on the key, so the string form is refused too; this
-    // asserts that rather than leaving it to be rediscovered.
-    it('refuses a customEngine given as a preset id, not just as a config', async () => {
+    // Yesterday this asserted the opposite, and the reversal is deliberate.
+    // The guard's own reason is that a custom engine "names an executable to
+    // spawn" — but `engine: 'codex'` spawns one too and is allowed here, so
+    // spawning was never the line. Arbitrary argv is, and a preset id cannot
+    // carry any: it selects one of the descriptions this package ships. Keeping
+    // it refused would also leave `-e custom` unreachable from the CLI, which
+    // is how the first outside contributor discovered the path was dead.
+    it('accepts a customEngine given as a preset id', async () => {
       await server.start();
 
       const res = await request(port, '/session/start', {
         method: 'POST',
-        body: { name: 'pwned', cwd: '/tmp', engine: 'custom', customEngine: 'some-preset' },
+        body: { name: 'preset-ok', cwd: '/tmp', engine: 'custom', customEngine: 'zcode' },
       });
 
-      expect(res.status).toBe(400);
-      expect(String((res.body as { error?: string }).error)).toContain('customEngine');
-      expect(manager.startSession).not.toHaveBeenCalled();
+      expect(res.status).not.toBe(400);
+      expect(manager.startSession).toHaveBeenCalled();
     });
 
     it('refuses a nested custom engine, wherever in the body it sits', async () => {

--- a/src/embedded-server.ts
+++ b/src/embedded-server.ts
@@ -83,17 +83,27 @@ function findCustomEngineKey(value: unknown, depth = 0, trail = ''): string | nu
   }
   for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
     const path = trail ? `${trail}.${key}` : key;
-    if (CUSTOM_ENGINE_KEY.test(key) && child !== undefined && child !== null) return path;
+    // A string here is a preset id: it selects one of the descriptions this
+    // package ships and cannot introduce a binary or argv of its own. That is
+    // the same class as naming a built-in engine, which this surface already
+    // allows — and `engine: 'codex'` spawns an executable too, so "spawns
+    // something" was never the line. Arbitrary argv is.
+    if (CUSTOM_ENGINE_KEY.test(key) && isInlineCustomEngine(child)) return path;
     const hit = findCustomEngineKey(child, depth + 1, path);
     if (hit) return hit;
   }
   return null;
 }
 
+/** An inline config — the form that carries a binary and argv of its own. */
+function isInlineCustomEngine(value: unknown): boolean {
+  return typeof value === 'object' && value !== null;
+}
+
 function rejectCustomEngineOverHttp(body: unknown): string | null {
   const key = findCustomEngineKey(body);
   if (!key) return null;
-  return `${key} is not accepted over HTTP: a custom engine names an executable to spawn, so it may only be configured by a local caller (MCP tool / SessionManager API). Use a built-in engine here.`;
+  return `${key} may not be given as an inline config over HTTP: it names an executable and its arguments, so it is accepted only from a local caller (MCP tool / SessionManager API). Pass the id of a bundled engine preset instead, or use a built-in engine.`;
 }
 
 /**


### PR DESCRIPTION
The CLI offered `-e custom` and had no way to satisfy it — no option supplied the engine, so the path failed with "customEngine config is required". The smoke script in `CONTRIBUTING.md` compounded it by naming a `--custom-engine` flag that did not exist, on a `clawo session start` subcommand spelled with a space rather than a hyphen. That script was written without being run.

@bwndlct hit this twice — first while preparing the ZCode preset (#96), then in #97 to correct the guide. The contribution path's first outside user walked straight into it, which is roughly the point of having one.

## The fix is in the CLI, not the prose

`clawo session-start --custom-engine <preset-id>` now works, and `clawo engines` lists the bundled presets with each one's provenance — read from the installed package, so it works with no server running.

## Narrowing the HTTP guard

The guard's stated reason has always been that a custom engine *names an executable to spawn*. But `engine: 'codex'` spawns one too and is accepted over the same surface, so spawning was never the line — **arbitrary argv is**.

- **inline config** — carries a binary and its arguments. Still local-only (MCP tool / `SessionManager` API).
- **preset id** — carries neither; it selects one of the descriptions this package ships. Same class as naming a built-in engine, so it is now accepted.

Verified in both directions against a running server: an inline config carrying `/bin/sh -c "touch …"` is refused and writes nothing, while a preset id reaches the spawn (`ENOENT` on the uninstalled adapter, which is the correct end of that path).

This reverses a test written the day before. That was the coarse version of the same boundary; the reversal is deliberate and the test now says why.

## Also

Adopts @bwndlct's explanation from #97 of why the HTTP surface refuses executable-bearing configuration — it stays true after the narrowing, and it was missing from our version.

1505 tests pass.